### PR TITLE
Feat / nodejs support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { TinyEmitter } from 'tiny-emitter';
 import Metrics from './metrics';
 import IStorageProvider from './storage-provider';
 import LocalStorageProvider from './storage-provider-local';
+import InMemoryStorageProvider from './storage-provider-inmemory';
 
 export interface IStaticContext {
     appName: string;
@@ -18,7 +19,6 @@ export interface IMutableContext {
 }
 
 export type IContext = IStaticContext & IMutableContext;
-export { IStorageProvider }
 
 export interface IConfig extends IStaticContext {
     url: string;
@@ -240,3 +240,6 @@ export class UnleashClient extends TinyEmitter {
         }
     }
 }
+
+// export storage providers from root module
+export { IStorageProvider, LocalStorageProvider, InMemoryStorageProvider }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { TinyEmitter } from 'tiny-emitter';
 import Metrics from './metrics';
-import IStorageProvider from './storage-provider';
+import type IStorageProvider from './storage-provider';
 import LocalStorageProvider from './storage-provider-local';
 import InMemoryStorageProvider from './storage-provider-inmemory';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export class UnleashClient extends TinyEmitter {
     private etag: string = '';
     private metrics: Metrics;
     private ready: Promise<void>;
-    private fetch?: typeof global['fetch'];
+    private fetch?: typeof globalThis['fetch'];
 
     constructor({
             storageProvider,
@@ -103,7 +103,7 @@ export class UnleashClient extends TinyEmitter {
             } 
             resolve();    
         });
-        this.fetch = fetch ?? global.fetch
+        this.fetch = fetch ?? globalThis?.fetch ?? window?.fetch
         
 
         this.metrics = new Metrics({

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ export class UnleashClient extends TinyEmitter {
 
     public async start(): Promise<void> {
         await this.ready;
-        if ('fetch' in window) {
+        if ('fetch' in global) {
             this.stop();
             const interval = this.refreshInterval;
             await this.fetchToggles();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export interface IMutableContext {
 }
 
 export type IContext = IStaticContext & IMutableContext;
-export type IFetch = typeof global.fetch
 export { IStorageProvider }
 
 export interface IConfig extends IStaticContext {
@@ -29,7 +28,7 @@ export interface IConfig extends IStaticContext {
     disableMetrics?: boolean;
     storageProvider?: IStorageProvider;
     context?: IMutableContext;
-    fetch?: IFetch;
+    fetch?: any;
 }
 
 export interface IVariant {
@@ -65,7 +64,7 @@ export class UnleashClient extends TinyEmitter {
     private etag: string = '';
     private metrics: Metrics;
     private ready: Promise<void>;
-    private fetch?: IFetch;
+    private fetch?: typeof global['fetch'];
 
     constructor({
             storageProvider,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,3 @@
-import { IFetch } from ".";
-
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/master/src/metrics.ts
 export interface MetricsOptions {
     appName: string;
@@ -7,7 +5,7 @@ export interface MetricsOptions {
     disableMetrics?: boolean;
     url: string;
     clientKey: string;
-    fetch?: IFetch;
+    fetch?: any;
 }
 
 interface Bucket {
@@ -25,7 +23,7 @@ export default class Metrics {
     private clientKey: string;
     private timer: any;
     private started: Date;
-    private fetch: IFetch;
+    private fetch: typeof global['fetch'];
 
     constructor({
         appName,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,3 +1,5 @@
+import { IFetch } from ".";
+
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/master/src/metrics.ts
 export interface MetricsOptions {
     appName: string;
@@ -5,6 +7,7 @@ export interface MetricsOptions {
     disableMetrics?: boolean;
     url: string;
     clientKey: string;
+    fetch?: IFetch;
 }
 
 interface Bucket {
@@ -22,6 +25,7 @@ export default class Metrics {
     private clientKey: string;
     private timer: any;
     private started: Date;
+    private fetch: IFetch;
 
     constructor({
         appName,
@@ -29,6 +33,7 @@ export default class Metrics {
         disableMetrics = false,
         url,
         clientKey,
+        fetch
     }: MetricsOptions) {
         this.disabled = disableMetrics;
         this.metricsInterval = metricsInterval * 1000;
@@ -37,6 +42,7 @@ export default class Metrics {
         this.started = new Date();
         this.clientKey = clientKey;
         this.resetBucket();
+        this.fetch = fetch ?? global.fetch
 
         if (typeof this.metricsInterval === 'number' && this.metricsInterval > 0) {
             // send first metrics after two seconds.
@@ -65,7 +71,7 @@ export default class Metrics {
         const url = `${this.url}/client/metrics`;
         const payload = this.getPayload();
 
-        await fetch(url, {
+        await this.fetch(url, {
             cache: 'no-cache',
             method: 'POST',
             headers: {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -23,7 +23,7 @@ export default class Metrics {
     private clientKey: string;
     private timer: any;
     private started: Date;
-    private fetch: typeof global['fetch'];
+    private fetch: typeof globalThis['fetch'];
 
     constructor({
         appName,
@@ -40,7 +40,7 @@ export default class Metrics {
         this.started = new Date();
         this.clientKey = clientKey;
         this.resetBucket();
-        this.fetch = fetch ?? global.fetch
+        this.fetch = fetch ?? globalThis?.fetch ?? window?.fetch
 
         if (typeof this.metricsInterval === 'number' && this.metricsInterval > 0) {
             // send first metrics after two seconds.

--- a/src/storage-provider-inmemory.test.ts
+++ b/src/storage-provider-inmemory.test.ts
@@ -1,0 +1,23 @@
+import InMemoryStorageProvider from './storage-provider-inmemory';
+
+describe('ImMemoryStorageProvider', () => {
+    it('should store and retrieve arbitrary values by key', async () => {
+        const store = new InMemoryStorageProvider();
+
+        await store.save('key1', 'value1');
+        await store.save('key2', { value2: 'true' });
+        await store.save('key3', ['value3']);
+        await store.save('key4', true);
+
+        expect(await store.get('key1')).toBe('value1');
+        expect(await store.get('key2')).toMatchObject({ value2: 'true' });
+        expect(await store.get('key3')).toMatchObject(['value3']);
+        expect(await store.get('key4')).toBe(true);
+    });
+
+    it('should return undefined for empty value', async () => {
+        const store = new InMemoryStorageProvider();
+
+        expect(await store.get('notDefinedKey')).toBe(undefined);
+    });
+});

--- a/src/storage-provider-inmemory.ts
+++ b/src/storage-provider-inmemory.ts
@@ -1,4 +1,4 @@
-import IStorageProvider from './storage-provider';
+import type IStorageProvider from './storage-provider';
 
 export default class ImMemoryStorageProvider implements IStorageProvider {
     private store = new Map();
@@ -8,6 +8,6 @@ export default class ImMemoryStorageProvider implements IStorageProvider {
     }
 
     public async get(name: string) {
-        return this.store.get(name);
+        return this.store.get(name)
     }
 }

--- a/src/storage-provider-inmemory.ts
+++ b/src/storage-provider-inmemory.ts
@@ -1,0 +1,13 @@
+import IStorageProvider from './storage-provider';
+
+export default class ImMemoryStorageProvider implements IStorageProvider {
+    private store = new Map();
+
+    public async save(name: string, data: any) {
+        this.store.set(name, data);
+    }
+
+    public async get(name: string) {
+        return this.store.get(name);
+    }
+}

--- a/src/storage-provider-local.ts
+++ b/src/storage-provider-local.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import IStorageProvider from './storage-provider';
+import type IStorageProvider from './storage-provider';
 
 export default class LocalStorageProvider implements IStorageProvider {
     private prefix = 'unleash:repository';


### PR DESCRIPTION
Use `global` instead of `window` and allow passing a `fetch` instance.

Example nodejs usage:

```typescript
import { UnleashClient } from 'unleash-proxy-client';
import fetch from 'node-fetch';

const store = new Map();
const inMemoryStorage: IStorageProvider = {
  save: async (key: string, value: any) => {
    store.set(key, value);
  },
  get: async (key: string) => store.get(key),
};

const unleash = new UnleashClient({
  url: config.UNLEASH_PROXY_URL,
  clientKey: config.UNLEASH_PROXY_SECRET,
  appName: config.UNLEASH_APP_NAME,
  storageProvider: inMemoryStorage,
  fetch,
});

unleash.start();
```