### PR TITLE
feat: setContextField() to updated single field on context

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ const unleash = new UnleashClient({
     appName: 'my-webapp'
 });
 
-// Used to set the context fields, shared with the Unleash Proxy
+// Used to set the context fields, shared with the Unleash Proxy. This 
+// method will replace the entire (mutable part) of the Unleash Context.
 unleash.updateContext({userId: '1233'});
+
+// Used to update a single field on the Unleash Context.
+unleash.setContextField('userId', '4141');
 
 // Start the background polling
 unleash.start();
@@ -68,6 +72,13 @@ unleash.on('update', () => {
     //do something useful
 });
 ```
+
+Available events:
+
+- **ready** - emitted after the SDK has successfully started and performed the initial fetch towards the Unleash Proxy. 
+- **update** - emitted every time the Unleash Proxy return a new feature toggle configuration. The SDK will emit this event as part of the initial fetch from the SDK.  
+
+> PS! Please remember that you should always register your event listeners before your call `unleash.start()`. If you register them after you have started the SDK you risk loosing important events. 
 
 ### SessionId - Important note!
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -354,3 +354,48 @@ test('Should use default environment', async () => {
 
     expect(url.searchParams.get('environment')).toEqual('default');
 });
+
+test('Should setContextField with userId', async () => {
+    const userId = 'some-id-123';
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const client = new UnleashClient(config);
+    client.setContextField('userId', userId);
+    const context = client.getContext();
+    expect(context.userId).toBe(userId);
+});
+
+test('Should setContextField with sessionId', async () => {
+    const sessionId = 'some-session-id-123';
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const client = new UnleashClient(config);
+    client.setContextField('sessionId', sessionId);
+    const context = client.getContext();
+    expect(context.sessionId).toBe(sessionId);
+});
+
+test('Should setContextField with remoteAddress', async () => {
+    const remoteAddress = '10.0.0.1';
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const client = new UnleashClient(config);
+    client.setContextField('remoteAddress', remoteAddress);
+    const context = client.getContext();
+    expect(context.remoteAddress).toBe(remoteAddress);
+});
+
+test('Should setContextField with custom property', async () => {
+    const clientId = 'some-client-id-443';
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const client = new UnleashClient(config);
+    client.setContextField('clientId', clientId);
+    const context = client.getContext();
+    expect(context.properties?.clientId).toBe(clientId);
+});
+
+test('Should override userId via setContextField', async () => {
+    const userId = 'some-user-id-552';
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', context: { userId: 'old' }};
+    const client = new UnleashClient(config);
+    client.setContextField('userId', userId);
+    const context = client.getContext();
+    expect(context.userId).toBe(userId);
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -391,6 +391,17 @@ test('Should setContextField with custom property', async () => {
     expect(context.properties?.clientId).toBe(clientId);
 });
 
+test('Should setContextField with custom property and keep existing props', async () => {
+    const clientId = 'some-client-id-443';
+    const initialContext = {properties: { someField: '123'}};
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', context: initialContext };
+    const client = new UnleashClient(config);
+    client.setContextField('clientId', clientId);
+    const context = client.getContext();
+    expect(context.properties?.clientId).toBe(clientId);
+    expect(context.properties?.someField).toBe(initialContext.properties.someField);
+});
+
 test('Should override userId via setContextField', async () => {
     const userId = 'some-user-id-552';
     const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', context: { userId: 'old' }};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import type IStorageProvider from './storage-provider';
 import LocalStorageProvider from './storage-provider-local';
 import InMemoryStorageProvider from './storage-provider-inmemory';
 
+const DEFINED_FIELDS = ['userId', 'sessionId', 'remoteAddress'];
+
 export interface IStaticContext {
     appName: string;
     environment?: string;
@@ -169,6 +171,15 @@ export class UnleashClient extends TinyEmitter {
 
     public getContext() {
         return {...this.context};
+    }
+
+    public setContextField(field: string, value: string) {
+        if(DEFINED_FIELDS.includes(field)) {
+            return this.updateContext({...this.context, [field]: value});
+        } else {
+            const properties = {...this.context.properties, [field]: value};
+            return this.updateContext({...this.context, properties});
+        }
     }
 
     private async init(): Promise<void> {


### PR DESCRIPTION
Today a user of the SDK will need to provide the full context to update the Unleash Context being used. It would be useful if the SDK could provide a setContextField(name, value) method which will only replace the specified field on the context, and preserve the rest.

fixes: #35 