### PR TITLE
DRAFT: Check local timestamp before sending fetch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ storageProvider | no | `LocalStorageProvider` | Allows you to inject a custom st
 |fetch | no | window.fetch | Allows you to override the fetch implementation to use. Useful in Node.js environments where you can inject `node-fetch` | 
 | bootstrap | no | `[]` | Allows you to bootstrap the cached feature toggle configuration. | 
 | bootstrapOverride | no| `true` | Should the boostrap automatically override cached data in the local-storage. Will only be used if boostrap is not an empty array. | 
-| ignoreFetchTimestamp | no| `false` | Set to true force always fetch proxy endpoint, ignoring local timestamp. Useful for development. | 
+| checkFetchTimestamp | no| `false` | Set to true to use timestamp feature to fetch proxy endpoint. Helpful if you don't want to fetch endpoint every page refresh. | 
 
 
 ### Listen for updates via the EventEmitter**

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ storageProvider | no | `LocalStorageProvider` | Allows you to inject a custom st
 |fetch | no | window.fetch | Allows you to override the fetch implementation to use. Useful in Node.js environments where you can inject `node-fetch` | 
 | bootstrap | no | `[]` | Allows you to bootstrap the cached feature toggle configuration. | 
 | bootstrapOverride | no| `true` | Should the boostrap automatically override cached data in the local-storage. Will only be used if boostrap is not an empty array. | 
+| ignoreFetchTimestamp | no| `false` | Set to true force always fetch proxy endpoint, ignoring local timestamp. Useful for development. | 
 
 
 ### Listen for updates via the EventEmitter**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "unleash-proxy-client",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.15.5",
@@ -8904,9 +8904,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "preversion": "rm -rf build && npm run build",
     "build": "npm run build:ts && npm run build:web",
-    "postinstall": "npm run build",
+    "prepare": "npm run build",
     "lint": "eslint ./src",
     "build:ts": "tsc",
     "build:web": "rollup -c rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "preversion": "rm -rf build && npm run build",
     "build": "npm run build:ts && npm run build:web",
+    "postinstall": "npm run build",
     "lint": "eslint ./src",
     "build:ts": "tsc",
     "build:web": "rollup -c rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "1.6.1",
+  "version": "1.6.0",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
   ],
   "scripts": {
     "preversion": "rm -rf build && npm run build",
-    "build": "npm run build:ts && npm run build:web",
-    "prepare": "npm run build",
-    "prepack": "npm run build",
+    "build": "yarn run build:ts && yarn run build:web || npm run build:ts && npm run build:web",
+    "prepare": "yarn build || npm run build",
     "lint": "eslint ./src",
     "build:ts": "tsc",
     "build:web": "rollup -c rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preversion": "rm -rf build && npm run build",
     "build": "npm run build:ts && npm run build:web",
     "prepare": "npm run build",
+    "prepack": "npm run build",
     "lint": "eslint ./src",
     "build:ts": "tsc",
     "build:web": "rollup -c rollup.config.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -331,7 +331,7 @@ test('Should ignore fetch when local timestamp set and time not passed', async (
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: false };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', checkFetchTimestamp: false };
     const client = new UnleashClient(config);
 
     
@@ -355,7 +355,7 @@ test('Should publish update when state changes after refreshInterval', async () 
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     
@@ -378,7 +378,7 @@ test('Should include etag in second request', async () => {
         [JSON.stringify(data), { status: 200, headers: { ETag: etag} }],
         [JSON.stringify(data), { status: 304, headers: { ETag: etag} }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -394,7 +394,7 @@ test('Should add clientKey as Authorization header', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web', ignoreFetchTimestamp: true };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
 
@@ -437,7 +437,7 @@ test('Should stop fetching when stop is called', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -472,8 +472,7 @@ test('Should include context fields on request', async () => {
         clientKey: '12',
         appName: 'web',
         environment: 'prod',
-        context,
-        ignoreFetchTimestamp: true
+        context
     };
     const client = new UnleashClient(config);
 
@@ -501,8 +500,7 @@ test('Should update context fields on request', async () => {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
-        environment: 'prod',
-        ignoreFetchTimestamp: true
+        environment: 'prod'
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -542,8 +540,7 @@ test('Should not add property fields when properties is an empty object', async 
         environment: 'prod',
         context: {
             properties: {}
-        },
-        ignoreFetchTimestamp: true
+        }
     };
     const client = new UnleashClient(config);
 
@@ -565,7 +562,7 @@ test('Should use default environment', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', ignoreFetchTimestamp: true };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -325,6 +325,30 @@ test('Should publish ready when initial fetch completed', (done) => {
     });
 });
 
+test('Should ignore fetch when local timestamp set and time not passed', async () => {
+    expect.assertions(1);
+    fetchMock.mockResponses(
+        [JSON.stringify(data), { status: 200 }],
+        [JSON.stringify(data), { status: 200 }],
+    );
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: false };
+    const client = new UnleashClient(config);
+
+    
+    let counts = 0;
+    client.on(EVENTS.UPDATE, () => {
+        counts++;
+        if (counts === 2) {
+            expect(fetchMock.mock.calls.length).toEqual(1);
+            client.stop();
+        }
+    });
+
+    await client.start();
+    jest.advanceTimersByTime(1001);
+    jest.advanceTimersByTime(1001);
+});
+
 test('Should publish update when state changes after refreshInterval', async () => {
     expect.assertions(1);
     fetchMock.mockResponses(
@@ -345,7 +369,6 @@ test('Should publish update when state changes after refreshInterval', async () 
     });
 
     await client.start();
-    Date.now = jest.fn(() => new Date(Date.UTC(2025, 1, 14)).valueOf())
     jest.advanceTimersByTime(1001);
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -331,9 +331,10 @@ test('Should publish update when state changes after refreshInterval', async () 
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
     const client = new UnleashClient(config);
 
+    
     let counts = 0;
     client.on(EVENTS.UPDATE, () => {
         counts++;
@@ -344,7 +345,7 @@ test('Should publish update when state changes after refreshInterval', async () 
     });
 
     await client.start();
-
+    Date.now = jest.fn(() => new Date(Date.UTC(2025, 1, 14)).valueOf())
     jest.advanceTimersByTime(1001);
 });
 
@@ -354,7 +355,7 @@ test('Should include etag in second request', async () => {
         [JSON.stringify(data), { status: 200, headers: { ETag: etag} }],
         [JSON.stringify(data), { status: 304, headers: { ETag: etag} }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -370,7 +371,7 @@ test('Should add clientKey as Authorization header', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web', ignoreFetchTimestamp: true };
     const client = new UnleashClient(config);
     await client.start();
 
@@ -413,7 +414,7 @@ test('Should stop fetching when stop is called', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web', ignoreFetchTimestamp: true };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -448,7 +449,8 @@ test('Should include context fields on request', async () => {
         clientKey: '12',
         appName: 'web',
         environment: 'prod',
-        context
+        context,
+        ignoreFetchTimestamp: true
     };
     const client = new UnleashClient(config);
 
@@ -476,7 +478,8 @@ test('Should update context fields on request', async () => {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
-        environment: 'prod'
+        environment: 'prod',
+        ignoreFetchTimestamp: true
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -516,7 +519,8 @@ test('Should not add property fields when properties is an empty object', async 
         environment: 'prod',
         context: {
             properties: {}
-        }
+        },
+        ignoreFetchTimestamp: true
     };
     const client = new UnleashClient(config);
 
@@ -538,7 +542,7 @@ test('Should use default environment', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', ignoreFetchTimestamp: true };
     const client = new UnleashClient(config);
     await client.start();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,6 @@ export class UnleashClient extends TinyEmitter {
         this.stop();
         const interval = this.refreshInterval;
         const nextFetchTimestamp = await this.getNextFetchNumber();
-        console.log(`number : ${nextFetchTimestamp}`)
         if (nextFetchTimestamp < Date.now()) {
             await this.fetchToggles();
         }
@@ -228,7 +227,7 @@ export class UnleashClient extends TinyEmitter {
 
     private async getNextFetchNumber(): Promise<number> { 
         const nextFetchTimestamp = await this.storage.get(storeKeyTimestamp) as number;
-        if(nextFetchTimestamp === undefined) {
+        if (nextFetchTimestamp === undefined || typeof nextFetchTimestamp !== 'number') {
             return 0;
         } else{
             return nextFetchTimestamp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ interface IConfig extends IStaticContext {
     fetch?: any;
     bootstrap?: IToggle[];
     bootstrapOverride?: boolean;
+    ignoreFetchTimestamp?: boolean;
 }
 
 interface IVariant {
@@ -87,6 +88,7 @@ export class UnleashClient extends TinyEmitter {
     private fetch: any;
     private bootstrap?: IToggle[];
     private bootstrapOverride: boolean;
+    private ignoreFetchTimestamp? : boolean
 
     constructor({
             storageProvider,
@@ -100,7 +102,9 @@ export class UnleashClient extends TinyEmitter {
             context,
             fetch = resolveFetch(),
             bootstrap,
-            bootstrapOverride = true}
+            bootstrapOverride = true,
+            ignoreFetchTimestamp: alwaysFetch
+        }
         : IConfig) {
         super();
         // Validations
@@ -136,6 +140,7 @@ export class UnleashClient extends TinyEmitter {
         this.fetch = fetch;
         this.bootstrap = bootstrap && bootstrap.length > 0 ? bootstrap : undefined;
         this.bootstrapOverride = bootstrapOverride;
+        this.ignoreFetchTimestamp = alwaysFetch;
 
         this.metrics = new Metrics({
             appName,
@@ -227,7 +232,7 @@ export class UnleashClient extends TinyEmitter {
 
     private async getNextFetchNumber(): Promise<number> { 
         const nextFetchTimestamp = await this.storage.get(storeKeyTimestamp) as number;
-        if (nextFetchTimestamp === undefined || typeof nextFetchTimestamp !== 'number') {
+        if (nextFetchTimestamp === undefined || typeof nextFetchTimestamp !== 'number' || this.ignoreFetchTimestamp) {
             return 0;
         } else{
             return nextFetchTimestamp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,12 +217,22 @@ export class UnleashClient extends TinyEmitter {
         await this.ready;
         this.stop();
         const interval = this.refreshInterval;
-        const nextFetchTimestamp = await this.storage.get(storeKeyTimestamp) as number;
+        const nextFetchTimestamp = await this.getNextFetchNumber();
+        console.log(`number : ${nextFetchTimestamp}`)
         if (nextFetchTimestamp < Date.now()) {
             await this.fetchToggles();
         }
         this.emit(EVENTS.READY);
         this.timerRef = setInterval(() => this.fetchToggles(), interval);
+    }
+
+    private async getNextFetchNumber(): Promise<number> { 
+        const nextFetchTimestamp = await this.storage.get(storeKeyTimestamp) as number;
+        if(nextFetchTimestamp === undefined) {
+            return 0;
+        } else{
+            return nextFetchTimestamp;
+        }
     }
 
     public stop(): void {


### PR DESCRIPTION
Currently Unleash Proxy endpoint is called every page refresh / opening sub page even when refresh interval time has not passed. 
Lib should add next fetch timestamp and check value before sending request. 