### PR TITLE
feat: async capabilites for updating context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ export class UnleashClient extends TinyEmitter {
         }
     }
 
-    public updateContext(context: IMutableContext) {
+    public async updateContext(context: IMutableContext): Promise<void> {
         // Give the user a nicer error message when including
         // static fields in the mutable context object
         // @ts-ignore
@@ -180,7 +180,7 @@ export class UnleashClient extends TinyEmitter {
         const staticContext = {environment: this.context.environment, appName: this.context.appName };
         this.context = {...staticContext, ...context};
         if (this.timerRef) {
-            this.fetchToggles();
+            await this.fetchToggles();
         }
     }
 


### PR DESCRIPTION
Problem:
Currently there is no way to wait on the resolution of the new flags for when the unleash context was updated.

Usually there is no problem as you fire `updateContext` and forget, but you can observe it as a problem when you have a side effect ( like redirecting the page ) and you need the new unleash variants / values before executing the side-effect. 

Currently there is no way to wait on the resolution of the flags after the context was updated.

This PR fixes it, it has been tested manually and all tests are passing.

This is backwards compatible as consumers can still fire and forget like before, but now can also wait for the updateContext to finish.

Depending on how you see this, can be a bug or a feature. Named it as a feat for the moment.

Thanks