### PR TITLE
task: Allow turning off proxy refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,20 @@ if(variant.name === 'blue') {
 
 The Unleash SDK takes the following options:
 
-| option   | required | default | description |
-|----------|----------|---------|-------------|
-| url      | yes | n/a | The Unleash Proxy URL to connect to. E.g.: `https://examples.com/proxy` |
-|clientKey | yes | n/a | The Unleash Proxy Secret to be used | 
-| appName | yes | n/a | The name of the application using this SDK. Will be used as part of the metrics sent to Unleash Proxy. Will also be part of the Unleash Context. | 
-|refreshInterval | no | 30 | How often, in seconds, the SDK should check for updated toggle configuration | 
-|metricsInterval | no | 60 | How often, in seconds, the SDK should send usage metrics back to Unleash Proxy | 
-| disableMetrics | no | false | Set this option to `true` if you want to disable usage metrics |
-storageProvider | no | `LocalStorageProvider` | Allows you to inject a custom storeProvider |
-| environment | no | 'default' | Identify the current environment. Will be part of the Unleash Context | 
-|fetch | no | window.fetch | Allows you to override the fetch implementation to use. Useful in Node.js environments where you can inject `node-fetch` | 
-| bootstrap | no | `[]` | Allows you to bootstrap the cached feature toggle configuration. | 
-| bootstrapOverride | no| `true` | Should the boostrap automatically override cached data in the local-storage. Will only be used if boostrap is not an empty array. | 
+| option            | required | default | description                                                                                                                                      |
+|-------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| url               | yes | n/a | The Unleash Proxy URL to connect to. E.g.: `https://examples.com/proxy`                                                                         |
+| clientKey         | yes | n/a | The Unleash Proxy Secret to be used                                                                                                             | 
+| appName           | yes | n/a | The name of the application using this SDK. Will be used as part of the metrics sent to Unleash Proxy. Will also be part of the Unleash Context. | 
+| refreshInterval   | no | 30 | How often, in seconds, the SDK should check for updated toggle configuration. If set to 0 will disable checking for updates                 |
+| disableRefresh    | no | false | If set to true, the client will not check for updated toggle configuration                                                                |
+| metricsInterval   | no | 60 | How often, in seconds, the SDK should send usage metrics back to Unleash Proxy                                                              | 
+| disableMetrics    | no | false | Set this option to `true` if you want to disable usage metrics                                                                           |
+| storageProvider   | no | `LocalStorageProvider` | Allows you to inject a custom storeProvider                                                                              |
+| environment       | no | 'default' | Identify the current environment. Will be part of the Unleash Context                                                                   | 
+| fetch             | no | window.fetch | Allows you to override the fetch implementation to use. Useful in Node.js environments where you can inject `node-fetch`                    | 
+| bootstrap         | no | `[]` | Allows you to bootstrap the cached feature toggle configuration.                                                                               | 
+| bootstrapOverride | no| `true` | Should the boostrap automatically override cached data in the local-storage. Will only be used if boostrap is not an empty array.     | 
 
 
 ### Listen for updates via the EventEmitter

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "unleash-proxy-client",
       "version": "1.7.1",
-      "license": "Apache 2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.15.5",
         "tiny-emitter": "^2.1.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { FetchMock } from 'jest-fetch-mock';
 import 'jest-localstorage-mock'
-import * as data from '../tests/example-data.json'; 
+import * as data from '../tests/example-data.json';
 import IStorageProvider from './storage-provider';
 import { EVENTS, IConfig, IMutableContext, UnleashClient } from './index';
 
@@ -49,12 +49,12 @@ test('Should handle error and return false for isEnabled', async () => {
         public async save(name: string, data: any) {
             return Promise.resolve();
         }
-    
+
         public async get(name: string) {
             return Promise.resolve([]);
         }
     }
-    const storageProvider = new Store 
+    const storageProvider = new Store
     const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', storageProvider };
     const client = new UnleashClient(config);
     await client.start();
@@ -63,14 +63,14 @@ test('Should handle error and return false for isEnabled', async () => {
     expect(isEnabled).toBe(false);
 });
 
-test('Should read session id form localStorage', async () => {
+test('Should read session id from localStorage', async () => {
     const sessionId = '123';
     fetchMock.mockReject();
     class Store implements IStorageProvider {
         public async save(name: string, data: any) {
             return Promise.resolve();
         }
-    
+
         public async get(name: string) {
             if(name === 'sessionId') {
                 return sessionId;
@@ -79,7 +79,7 @@ test('Should read session id form localStorage', async () => {
             }
         }
     }
-    const storageProvider = new Store 
+    const storageProvider = new Store
     const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', storageProvider };
     const client = new UnleashClient(config);
     await client.start();
@@ -87,7 +87,7 @@ test('Should read session id form localStorage', async () => {
     expect(context.sessionId).toBe(sessionId);
 });
 
-test('Should read toggles form localStorage', async () => {
+test('Should read toggles from localStorage', async () => {
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     const toggles = [{
         "name": "featureToggleBackup",
@@ -102,7 +102,7 @@ test('Should read toggles form localStorage', async () => {
         public async save(name: string, data: any) {
             return Promise.resolve();
         }
-    
+
         public async get(name: string) {
             if(name === 'repo') {
                 return Promise.resolve(toggles);
@@ -160,7 +160,7 @@ test('Should bootstrap data when bootstrap is provided', async () => {
     localStorage.setItem(storeKey, JSON.stringify(initialData))
     expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));
 
-    const config: IConfig = { 
+    const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
@@ -172,7 +172,7 @@ test('Should bootstrap data when bootstrap is provided', async () => {
     });
 
     expect(client.getAllToggles()).toStrictEqual(bootstrap);
-    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(bootstrap));  
+    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(bootstrap));
 });
 
 test('Should not bootstrap data when bootstrapOverride is false and localStorage is not empty', async () => {
@@ -216,7 +216,7 @@ test('Should not bootstrap data when bootstrapOverride is false and localStorage
     localStorage.setItem(storeKey, JSON.stringify(initialData))
     expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));
 
-    const config: IConfig = { 
+    const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
@@ -229,7 +229,7 @@ test('Should not bootstrap data when bootstrapOverride is false and localStorage
     });
 
     expect(client.getAllToggles()).toStrictEqual(initialData);
-    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));  
+    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));
 });
 
 test('Should bootstrap when bootstrapOverride is false and local storage is empty', async () => {
@@ -256,7 +256,7 @@ test('Should bootstrap when bootstrapOverride is false and local storage is empt
     localStorage.setItem(storeKey, JSON.stringify([]))
     expect(localStorage.getItem(storeKey)).toBe(JSON.stringify([]));
 
-    const config: IConfig = { 
+    const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
@@ -269,7 +269,7 @@ test('Should bootstrap when bootstrapOverride is false and local storage is empt
     });
 
     expect(client.getAllToggles()).toStrictEqual(bootstrap);
-    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(bootstrap));  
+    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(bootstrap));
 });
 
 test('Should not bootstrap data when bootstrap is []', async () => {
@@ -296,7 +296,7 @@ test('Should not bootstrap data when bootstrap is []', async () => {
     localStorage.setItem(storeKey, JSON.stringify(initialData))
     expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));
 
-    const config: IConfig = { 
+    const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
@@ -309,7 +309,7 @@ test('Should not bootstrap data when bootstrap is []', async () => {
     });
 
     expect(client.getAllToggles()).toStrictEqual(initialData);
-    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));  
+    expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(initialData));
 });
 
 test('Should publish ready when initial fetch completed', (done) => {
@@ -331,12 +331,12 @@ test('Should publish error when initial init fails', (done) => {
         public async save(name: string, data: any): Promise<void> {
             return Promise.reject(givenError);
         }
-    
+
         public async get(name: string): Promise<any> {
             return Promise.reject(givenError);
         }
     }
-    
+
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     fetchMock.mockResponseOnce(JSON.stringify(data));
 
@@ -352,7 +352,7 @@ test('Should publish error when initial init fails', (done) => {
 
 test('Should publish error when fetch fails', (done) => {
     const givenError = new Error('Error');
-    
+
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     fetchMock.mockReject(givenError);
 
@@ -386,6 +386,18 @@ test('Should publish update when state changes after refreshInterval', async () 
     await client.start();
 
     jest.advanceTimersByTime(1001);
+});
+
+test(`If refresh is disabled should not fetch`, async () => {
+    fetchMock.mockResponses(
+        [JSON.stringify(data), { status: 200 }],
+        [JSON.stringify(data), { status: 200 }],
+    );
+    const config: IConfig = { disableRefresh: true, url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const client = new UnleashClient(config);
+    await client.start();
+    jest.advanceTimersByTime(100000);
+    expect(fetchMock.mock.calls.length).toEqual(1); // Never called again
 });
 
 test('Should include etag in second request', async () => {


### PR DESCRIPTION
After a meeting with customer that wanted the possibility to disable
refreshing, they only needed toggle status updated at startup.

This PR adds the possibility to not fetch via a new `disableRefresh` flag, or by setting refreshInterval to `0` the client will no longer perform refreshes.