### PR TITLE
feat: additional possibility to customize header for clientKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The Unleash SDK takes the following options:
 | fetch             | no | window.fetch | Allows you to override the fetch implementation to use. Useful in Node.js environments where you can inject `node-fetch`                    | 
 | bootstrap         | no | `[]` | Allows you to bootstrap the cached feature toggle configuration.                                                                               | 
 | bootstrapOverride | no| `true` | Should the boostrap automatically override cached data in the local-storage. Will only be used if boostrap is not an empty array.     | 
+| headerName        | no| `Authorization` | Provides possiblity to specify custom header that is passed to Unleash / Unleash Proxy with the `clientKey` | 
 
 
 ### Listen for updates via the EventEmitter

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -838,3 +838,25 @@ test('Initializing client twice should show a console warning', async () => {
     // Expect console.error to be called once before start runs.
     expect(console.error).toBeCalledTimes(2);
 });
+
+test('Should pass under custom header clientKey', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(data));
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        headerName: 'NotAuthorization'
+    };
+    const client = new UnleashClient(config);
+
+    client.on(EVENTS.UPDATE, () => {
+        expect(fetchMock.mock.calls.length).toEqual(1);
+        expect(fetchMock.mock.calls[0][1].headers).toMatchObject({ 'NotAuthorization': '12' });
+        client.stop();
+    });
+
+    await client.start();
+
+    jest.advanceTimersByTime(999);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ interface IConfig extends IStaticContext {
     fetch?: any;
     bootstrap?: IToggle[];
     bootstrapOverride?: boolean;
+    headerName?: string
 }
 
 interface IVariant {
@@ -88,6 +89,7 @@ export class UnleashClient extends TinyEmitter {
     private fetch: any;
     private bootstrap?: IToggle[];
     private bootstrapOverride: boolean;
+    private headerName: string;
 
     constructor({
         storageProvider,
@@ -103,6 +105,7 @@ export class UnleashClient extends TinyEmitter {
         fetch = resolveFetch(),
         bootstrap,
         bootstrapOverride = true,
+        headerName = 'Authorization'
     }: IConfig) {
         super();
         // Validations
@@ -119,6 +122,7 @@ export class UnleashClient extends TinyEmitter {
         this.toggles = bootstrap && bootstrap.length > 0 ? bootstrap : [];
         this.url = new URL(`${url}`);
         this.clientKey = clientKey;
+        this.headerName = headerName;
         this.storage = storageProvider || new LocalStorageProvider();
         this.refreshInterval = disableRefresh ? 0 : refreshInterval * 1000;
         this.context = { appName, environment, ...context };
@@ -301,7 +305,7 @@ export class UnleashClient extends TinyEmitter {
                 const response = await this.fetch(urlWithQuery.toString(), {
                     cache: 'no-cache',
                     headers: {
-                        Authorization: this.clientKey,
+                        [this.headerName]: this.clientKey,
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'If-None-Match': this.etag,

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ export class UnleashClient extends TinyEmitter {
             url,
             clientKey,
             fetch,
+            headerName
         });
     }
 

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -18,6 +18,7 @@ test('should be disabled by flag disableMetrics', async () => {
         url: 'http://localhost:3000',
         clientKey: '123',
         fetch: fetchMock,
+        headerName: 'Authorization'
     });
 
     metrics.count('foo', true);
@@ -35,6 +36,7 @@ test('should send metrics', async () => {
         url: 'http://localhost:3000',
         clientKey: '123',
         fetch: fetchMock,
+        headerName: 'Authorization'
     });
 
     metrics.count('foo', true);
@@ -53,6 +55,25 @@ test('should send metrics', async () => {
     expect(content.bucket.toggles.bar.no).toEqual(1);
 });
 
+test('should send metrics under custom header', async () => {
+    const metrics = new Metrics({
+        appName: 'test',
+        metricsInterval: 0,
+        disableMetrics: false,
+        url: 'http://localhost:3000',
+        clientKey: '123',
+        fetch: fetchMock,
+        headerName: 'NotAuthorization'
+    });
+
+    metrics.count('foo', true);
+    
+    await metrics.sendMetrics();
+
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({ 'NotAuthorization': '123' });
+});
+
 test('Should send initial metrics after 2 seconds', () => {
     const metrics = new Metrics({
         appName: 'test',
@@ -61,6 +82,7 @@ test('Should send initial metrics after 2 seconds', () => {
         url: 'http://localhost:3000',
         clientKey: '123',
         fetch: fetchMock,
+        headerName: 'Authorization'
     });
 
     metrics.start();
@@ -82,6 +104,7 @@ test('should send metrics based on timer interval', async () => {
         url: 'http://localhost:3000',
         clientKey: '123',
         fetch: fetchMock,
+        headerName: 'Authorization'
     });
 
     metrics.start();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,6 +6,7 @@ export interface MetricsOptions {
     url: string;
     clientKey: string;
     fetch: any;
+    headerName: string
 }
 
 interface Bucket {
@@ -29,6 +30,7 @@ export default class Metrics {
     private clientKey: string;
     private timer: any;
     private fetch: any;
+    private headerName: string
 
     constructor({
         appName,
@@ -37,6 +39,7 @@ export default class Metrics {
         url,
         clientKey,
         fetch,
+        headerName
     }: MetricsOptions) {
         this.disabled = disableMetrics;
         this.metricsInterval = metricsInterval * 1000;
@@ -45,6 +48,7 @@ export default class Metrics {
         this.clientKey = clientKey;
         this.bucket = this.createEmptyBucket();
         this.fetch = fetch;
+        this.headerName = headerName 
     }
 
     public start() {
@@ -93,7 +97,7 @@ export default class Metrics {
             cache: 'no-cache',
             method: 'POST',
             headers: {
-                Authorization: this.clientKey,
+                [this.headerName]: this.clientKey,
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
             },


### PR DESCRIPTION
According to https://github.com/Unleash/unleash-proxy/pull/39 I'm providing possibility to specify proxy secret header name (client key) also from browser side :) 