### PR TITLE
Add a default value parameter to isEnabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,9 +163,9 @@ export class UnleashClient extends TinyEmitter {
         return [...this.toggles];
     }
 
-    public isEnabled(toggleName: string): boolean {
+    public isEnabled(toggleName: string, defaultValue = false): boolean {
         const toggle = this.toggles.find((t) => t.name === toggleName);
-        const enabled = toggle ? toggle.enabled : false;
+        const enabled = toggle ? toggle.enabled : defaultValue;
         this.metrics.count(toggleName, enabled);
         return enabled;
     }


### PR DESCRIPTION
Change isEnable to comply with Unleash's [official Client Specification](https://docs.getunleash.io/client-specification#the-basics). It stipulates that
> The basic isEnabled method should also accept a default value. This should be used if the client does not know anything about a particular toggle. If the user does not specify a default value, false should be returned for unknown feature toggles.