### PR TITLE
Add support for passing URL instance to unleash client constructor

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,6 +23,17 @@ test('Should initialize unleash-client', () => {
     expect(config.url).toBe('http://localhost/test');
 });
 
+test('Should initialize unleash-client when using URL instance', () => {
+    const url = new URL('test', 'http://localhost');
+    const config: IConfig = {
+        url,
+        clientKey: '12',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    expect(client).toHaveProperty('url', url);
+});
+
 test('Should perform an initial fetch', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
     const config: IConfig = {
@@ -739,7 +750,6 @@ test('Should note include context fields with "null" value', async () => {
     expect(url.searchParams.has('remoteAddress')).toBe(false);
     expect(url.searchParams.has('sessionId')).toBe(true);
     expect(url.searchParams.get('sessionId')).toBe('0');
-    
 });
 
 test('Should update context fields on request', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ interface IMutableContext {
 type IContext = IStaticContext & IMutableContext;
 
 interface IConfig extends IStaticContext {
-    url: string;
+    url: string | URL;
     clientKey: string;
     disableRefresh?: boolean;
     refreshInterval?: number;
@@ -130,7 +130,7 @@ export class UnleashClient extends TinyEmitter {
         }
         this.eventsHandler = new EventsHandler();
         this.toggles = bootstrap && bootstrap.length > 0 ? bootstrap : [];
-        this.url = new URL(`${url}`);
+        this.url = typeof url === 'string' ? new URL(`${url}`) : url;
         this.clientKey = clientKey;
         this.headerName = headerName;
         this.storage = storageProvider || new LocalStorageProvider();
@@ -162,7 +162,7 @@ export class UnleashClient extends TinyEmitter {
             appName,
             metricsInterval,
             disableMetrics,
-            url,
+            url: this.url.toString(),
             clientKey,
             fetch,
             headerName,


### PR DESCRIPTION
Gives consumer greater control over format of url whilst still ensuring that it is valid.
Makes it possible to use relative urls (as requested in #59) when initialising client.