### PR TITLE
BREAKING CHANGE: remove built-in support for react native async storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,13 @@ unleash.stop()
 
 ### Custom store
 
-This SDK will use [@react-native-async-storage/async-storage](https://react-native-async-storage.github.io/async-storage/) to backup feature toggles locally. This is useful for bootstrapping the SDK the next time the user comes back to your application. 
+This SDK can work with React Native storage [@react-native-async-storage/async-storage](https://react-native-async-storage.github.io/async-storage/) or [react-native-shared-preferences](https://github.com/sriraman/react-native-shared-preferences) and many more to backup feature toggles locally. This is useful for bootstrapping the SDK the next time the user comes back to your application. 
 
 You can provide your own storage implementation. 
 
-Example: 
+Examples: 
 
-```js
-
+```typescript
 import SharedPreferences from 'react-native-shared-preferences';
 import { UnleashClient } from 'unleash-proxy-client';
 
@@ -159,15 +158,40 @@ const unleash = new UnleashClient({
     url: 'https://eu.unleash-hosted.com/hosted/proxy',
     clientKey: 'your-proxy-key',
     appName: 'my-webapp',
-	storage: {
-		save: (name: string, data: any) => SharedPreferences.setItem(name, data),
-		get: (name: string) => SharedPreferences.getItem(name, (val) => val)
-	},
+    storageProvider: {
+      save: (name: string, data: any) => SharedPreferences.setItem(name, data),
+      get: (name: string) => SharedPreferences.getItem(name, (val) => val)
+    },
+});
+```
+
+```typescript
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { UnleashClient } from 'unleash-proxy-client';
+
+const PREFIX = 'unleash:repository';
+
+const unleash = new UnleashClient({
+    url: 'https://eu.unleash-hosted.com/hosted/proxy',
+    clientKey: 'your-proxy-key',
+    appName: 'my-webapp',
+    storageProvider: {
+       save: (name: string, data: any) => {
+        const repo = JSON.stringify(data);
+        const key = `${PREFIX}:${name}`;
+        return AsyncStorage.setItem(key, repo);
+      },
+      get: (name: string) => {
+        const key = `${PREFIX}:${name}`;
+        const data = await AsyncStorage.getItem(key);
+        return data ? JSON.parse(data) : undefined;
+      }
+    },
 });
 ```
 ## How to use in node.js
 
-This SDK can also be used in node.js applications (from v1.4.0). Please note that you will need to provide a valid "fetch" implementation. Only ECMAScript modules is exported from this package.  
+This SDK can also be used in node.js applications (from v1.4.0). Please note that you will need to provide a valid "fetch" implementation. Only ECMAScript modules is exported from this package.
 
 ```js
 import fetch from 'node-fetch';

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,14 +809,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@react-native-async-storage/async-storage": {
-      "version": "1.15.17",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz",
-      "integrity": "sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==",
-      "requires": {
-        "merge-options": "^3.0.4"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2547,11 +2539,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -3348,14 +3335,6 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
-      }
-    },
-    "merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "requires": {
-        "is-plain-obj": "^2.1.0"
       }
     },
     "merge-stream": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "uglify-js": "^3.6.0"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.17",
     "tiny-emitter": "^2.1.0",
     "uuid": "^8.3.2"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { TinyEmitter } from 'tiny-emitter';
 import Metrics from './metrics';
 import type IStorageProvider from './storage-provider';
-import LocalStorageProvider from './storage-provider-local';
 import InMemoryStorageProvider from './storage-provider-inmemory';
+import LocalStorageProvider from './storage-provider-local';
 import EventsHandler from './events-handler';
 import { notNullOrUndefined } from './util';
 

--- a/src/storage-provider-local.test.ts
+++ b/src/storage-provider-local.test.ts
@@ -1,0 +1,22 @@
+import LocalStorageProvider from './storage-provider-local';
+
+describe('LocalStorageProvider', () => {
+    it('should store and retrieve arbitrary values by key', async () => {
+        const store = new LocalStorageProvider();
+
+        await store.save('key1', 'value1');
+        await store.save('key2', { value2: 'true' });
+        await store.save('key3', ['value3']);
+        await store.save('key4', true);
+
+        expect(await store.get('key1')).toBe('value1');
+        expect(await store.get('key2')).toMatchObject({ value2: 'true' });
+        expect(await store.get('key3')).toMatchObject(['value3']);
+        expect(await store.get('key4')).toBe(true);
+    });
+
+    it('should return undefined for empty value', async () => {
+        const store = new LocalStorageProvider();
+        expect(await store.get('notDefinedKey')).toBe(undefined);
+    });
+});

--- a/src/storage-provider-local.ts
+++ b/src/storage-provider-local.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import type IStorageProvider from './storage-provider';
 
 export default class LocalStorageProvider implements IStorageProvider {
@@ -8,16 +7,16 @@ export default class LocalStorageProvider implements IStorageProvider {
         const repo = JSON.stringify(data);
         const key = `${this.prefix}:${name}`;
         try {
-            await AsyncStorage.setItem(key, repo);
+            window.localStorage.setItem(key, repo);
         } catch (ex) {
             console.error(ex);
         }
     }
 
-    public async get(name: string) {
+    public get(name: string) {
         try {
             const key = `${this.prefix}:${name}`;
-            const data = await AsyncStorage.getItem(key);
+            const data = window.localStorage.getItem(key);
             return data ? JSON.parse(data) : undefined;
         } catch (e) {
             // tslint:disable-next-line


### PR DESCRIPTION
[Breaking Change] v2

Removing built-in support for react-native (will become optional as custom storageProvider provided by developer itself)
* if will remove a lot of installed dependencies (for react-native it's huge...)
* it will reduce amount of packages that needs to be maintained (dependabot, renovate...)
* it's a suggestion to create own client for react-native if more custom things are needed 
* instead of `react-native-async-storage` which fallbacks to window.localStorage I just used window.localStorage

Kind regards
Dziczek! 