### PR TITLE
fix: add missing property `enabled` to `IVariant` interface

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,6 +55,24 @@ test('Should have correct variant', async () => {
     expect(payload.value).toBe('some-text');
 });
 
+test('Should return default variant if not found', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(data));
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    await client.start();
+    const variant = client.getVariant('missingToggle');
+    const payload = variant.payload || { type: 'undef', value: '' };
+    client.stop();
+    expect(variant.name).toBe('disabled');
+    expect(variant.enabled).toBe(false);
+    expect(payload.type).toBe('undef');
+    expect(payload.value).toBe('');
+});
+
 test('Should handle error and return false for isEnabled', async () => {
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     fetchMock.mockReject();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,6 +50,7 @@ test('Should have correct variant', async () => {
     const payload = variant.payload || { type: 'undef', value: '' };
     client.stop();
     expect(variant.name).toBe('green');
+    expect(variant.enabled).toBe(true);
     expect(payload.type).toBe('string');
     expect(payload.value).toBe('some-text');
 });
@@ -739,7 +740,7 @@ test('Should note include context fields with "null" value', async () => {
     expect(url.searchParams.has('remoteAddress')).toBe(false);
     expect(url.searchParams.has('sessionId')).toBe(true);
     expect(url.searchParams.get('sessionId')).toBe('0');
-    
+
 });
 
 test('Should update context fields on request', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ interface IConfig extends IStaticContext {
 
 interface IVariant {
     name: string;
+    enabled: boolean;
     payload?: {
         type: string;
         value: string;
@@ -67,7 +68,7 @@ const IMPRESSION_EVENTS = {
     GET_VARIANT: 'getVariant',
 };
 
-const defaultVariant: IVariant = { name: 'disabled' };
+const defaultVariant: IVariant = { name: 'disabled', enabled: false };
 const storeKey = 'repo';
 
 export const resolveFetch = () => {


### PR DESCRIPTION
This PR adds the missing property `enabled` to the `IVariant` interface.

Closes #77

Let me know if something is missing ;)