### PR TITLE
fix: add browser field to package.json for CDNs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A browser client that can be used together with the unleash-proxy.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "browser": "./build/main.min.js",
   "files": [
     "build",
     "examples",


### PR DESCRIPTION
Should make imports like these work as expected:

```html
<script src="https://cdn.jsdelivr.net/npm/unleash-proxy-client"></script>
<script src="https://unpkg.com/unleash-proxy-client"></script>
```