### PR TITLE
Revert "fix: add browser field to package.json for CDNs (#104)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A browser client that can be used together with the unleash-proxy.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
-  "browser": "./build/main.min.js",
   "files": [
     "build",
     "examples",


### PR DESCRIPTION
Seems like it breaks the React proxy client build.