### PR TITLE
enhancement: emit errors if response is not ok

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ unleash.on('update', () => {
 
 #### Available events:
 
-- **error** - emitted when an error occurs on init, or when fetch function fails. The error object is sent as payload.
+- **error** - emitted when an error occurs on init, or when fetch function fails, or when fetch receives a non-ok response object. The error object is sent as payload.
 - **initialized** - emitted after the SDK has read local cached data in the storageProvider. 
 - **ready** - emitted after the SDK has successfully started and performed the initial fetch towards the Unleash Proxy. 
 - **update** - emitted every time the Unleash Proxy return a new feature toggle configuration. The SDK will emit this event as part of the initial fetch from the SDK.  

--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,14 +2056,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001306",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-      "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
+      "version": "1.0.30001399",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
+      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7665,9 +7671,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001306",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-      "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
+      "version": "1.0.30001399",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
+      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
       "dev": true
     },
     "chalk": {
@@ -7778,7 +7784,7 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.7"
       }
     },
     "cross-spawn": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -530,6 +530,24 @@ test('Should publish error when fetch fails', (done) => {
     });
 });
 
+test.each([400, 401, 403, 404, 429, 500, 502, 503])('Should publish error when fetch receives a %d error', async (errorCode) => {
+    expect.assertions(1);
+    jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
+    fetchMock.mockResponseOnce("{}", { status: errorCode});
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    client.on(EVENTS.ERROR, (e: any) => {
+        expect(e).toStrictEqual({ type: 'HttpError', code: errorCode});
+
+    });
+    await client.start();
+})
+
 test('Should publish update when state changes after refreshInterval', async () => {
     expect.assertions(1);
     fetchMock.mockResponses(

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,6 +368,9 @@ export class UnleashClient extends TinyEmitter {
                         this.emit(EVENTS.READY);
                         this.readyEventEmitted = true;
                     }
+                } else if (!response.ok) {
+                    console.error('Unleash: Fetching feature toggles did not have an ok response');
+                    this.emit(EVENTS.ERROR, { type: 'HttpError', code: response.status })
                 }
             } catch (e) {
                 console.error('Unleash: unable to fetch feature toggles', e);


### PR DESCRIPTION
This now checks if response is not ok, if it is not, we emit an error object with a type and a statusCode.

I'm wondering if we should add more logic when we receive a 401 and just stop the poll; but that can be a different improvement.
fixes #108 