### PR TITLE
fix: merge sessionId instead of removing it

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -818,6 +818,36 @@ test('Should update context fields on request', async () => {
     expect(url.searchParams.get('environment')).toEqual('prod');
 });
 
+test('Should not replace sessionId when updating context', async () => {
+    fetchMock.mockResponses(
+        [JSON.stringify(data), { status: 200 }],
+        [JSON.stringify(data), { status: 304 }]
+    );
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        environment: 'prod',
+    };
+    const client = new UnleashClient(config);
+    await client.start();
+    const context = client.getContext();
+    await client.updateContext({
+        userId: '123',
+        remoteAddress: 'address',
+        properties: {
+            property1: 'property1',
+            property2: 'property2',
+        },
+    });
+
+    jest.advanceTimersByTime(1001);
+
+    const url = new URL(getTypeSafeRequestUrl(fetchMock));
+
+    expect(url.searchParams.get('sessionId')).toEqual(context.sessionId?.toString());
+});
+
 test('Should not add property fields when properties is an empty object', async () => {
     fetchMock.mockResponses(
         [JSON.stringify(data), { status: 200 }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,7 @@ export class UnleashClient extends TinyEmitter {
         const staticContext = {
             environment: this.context.environment,
             appName: this.context.appName,
+            sessionId: this.context.sessionId,
         };
         this.context = { ...staticContext, ...context };
         if (this.timerRef) {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
It is unexpected for "uppdateContext" to remove
the automatically generated sessionId. This fix keeps the sessionId as long as it is not specified in the new context passed in to the "updateContext" method.

<!-- Does it close an issue? Multiple? -->
Closes #118 

