### PR TITLE
feat: add overide to get all impression events

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The Unleash SDK takes the following options:
 | bootstrapOverride | no| `true` | Should the bootstrap automatically override cached data in the local-storage. Will only be used if bootstrap is not an empty array.     | 
 | headerName        | no| `Authorization` | Provides possiblity to specify custom header that is passed to Unleash / Unleash Proxy with the `clientKey` | 
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used. | 
-| impressionDataAll | no| `false` | Allows you to trigger "impression" events for all `getToggle` and `getVariant` invocations. This is particular useful for "disabled" feature toggles which are not visible to frontend SDKs. | 
+| impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. | 
 
 ### Listen for updates via the EventEmitter
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The Unleash SDK takes the following options:
 | bootstrapOverride | no| `true` | Should the bootstrap automatically override cached data in the local-storage. Will only be used if bootstrap is not an empty array.     | 
 | headerName        | no| `Authorization` | Provides possiblity to specify custom header that is passed to Unleash / Unleash Proxy with the `clientKey` | 
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used. | 
-
+| impressionDataAll | no| `false` | Allows you to trigger "impression" events for all `getToggle` and `getVariant` invocations. This is particular useful for "disabled" feature toggles which are not visible to frontend SDKs. | 
 
 ### Listen for updates via the EventEmitter
 

--- a/src/events-handler.ts
+++ b/src/events-handler.ts
@@ -10,16 +10,16 @@ class EventsHandler {
         context: IContext,
         enabled: boolean,
         featureName: string,
-        impressionData: boolean,
         eventType: string,
+        impressionData?: boolean,
         variant?: string
     ) {
         const baseEvent = this.createBaseEvent(
             context,
             enabled,
             featureName,
+            eventType,
             impressionData,
-            eventType
         );
 
         if (variant) {
@@ -35,8 +35,8 @@ class EventsHandler {
         context: IContext,
         enabled: boolean,
         featureName: string,
-        impressionData: boolean,
-        eventType: string
+        eventType: string,
+        impressionData?: boolean,
     ) {
         return {
             eventType,

--- a/src/events-handler.ts
+++ b/src/events-handler.ts
@@ -10,6 +10,7 @@ class EventsHandler {
         context: IContext,
         enabled: boolean,
         featureName: string,
+        impressionData: boolean,
         eventType: string,
         variant?: string
     ) {
@@ -17,6 +18,7 @@ class EventsHandler {
             context,
             enabled,
             featureName,
+            impressionData,
             eventType
         );
 
@@ -33,6 +35,7 @@ class EventsHandler {
         context: IContext,
         enabled: boolean,
         featureName: string,
+        impressionData: boolean,
         eventType: string
     ) {
         return {

--- a/src/events-handler.ts
+++ b/src/events-handler.ts
@@ -44,6 +44,7 @@ class EventsHandler {
             context,
             enabled,
             featureName,
+            impressionData
         };
     }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1114,6 +1114,79 @@ test('Should call getVariant event when impressionData is true', (done) => {
     client.on(EVENTS.IMPRESSION, (event: any) => {
         expect(event.featureName).toBe('impression-variant');
         expect(event.eventType).toBe('getVariant');
+        expect(event.impressionData).toBe(true);
+        client.stop();
+        done();
+    });
+});
+
+test('Should not call isEnabled event when impressionData is false', (done) => {
+    const bootstrap = [
+        {
+            name: 'impression',
+            enabled: true,
+            variant: {
+                name: 'disabled',
+                enabled: false,
+            },
+            impressionData: false,
+        },
+    ];
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap,
+    };
+    const client = new UnleashClient(config);
+    client.start();
+
+    client.on(EVENTS.READY, () => {
+        const isEnabled = client.isEnabled('impression');
+        expect(isEnabled).toBe(true);
+        client.stop();
+        done();
+    });
+
+    client.on(EVENTS.IMPRESSION, () => {
+        client.stop();
+        fail('SDK should not emit impression event');
+    });
+});
+
+test('Should call getVariant event when impressionData is false and impressionDataAll is true', (done) => {
+    const bootstrap = [
+        {
+            name: 'impression-variant',
+            enabled: true,
+            variant: {
+                name: 'disabled',
+                enabled: false,
+            },
+            impressionData: false,
+        },
+    ];
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap,
+        impressionDataAll: true,
+    };
+    const client = new UnleashClient(config);
+    client.start();
+
+    client.on(EVENTS.READY, () => {
+        const isEnabled = client.getVariant('impression-variant');
+        expect(isEnabled).toBe(true);
+    });
+
+    client.on(EVENTS.IMPRESSION, (event: any) => {
+        expect(event.featureName).toBe('impression-variant');
+        expect(event.eventType).toBe('getVariant');
+        expect(event.impressionData).toBe(false);
         client.stop();
         done();
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1155,6 +1155,81 @@ test('Should not call isEnabled event when impressionData is false', (done) => {
     });
 });
 
+test('Should call isEnabled event when impressionData is false and impressionDataAll is true', (done) => {
+    const bootstrap = [
+        {
+            name: 'impression',
+            enabled: true,
+            variant: {
+                name: 'disabled',
+                enabled: false,
+            },
+            impressionData: false,
+        },
+    ];
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap,
+        impressionDataAll: true,
+    };
+    const client = new UnleashClient(config);
+    client.start();
+
+    client.on(EVENTS.READY, () => {
+        const isEnabled = client.isEnabled('impression');
+        expect(isEnabled).toBe(true);
+    });
+
+    client.on(EVENTS.IMPRESSION, (event: any) => {
+        expect(event.featureName).toBe('impression');
+        expect(event.eventType).toBe('isEnabled');
+        expect(event.impressionData).toBe(undefined);
+        client.stop();
+        done();
+    });
+});
+
+test('Should call isEnabled event when toggle is unknown and impressionDataAll is true', (done) => {
+    const bootstrap = [
+        {
+            name: 'impression',
+            enabled: true,
+            variant: {
+                name: 'disabled',
+                enabled: false,
+            },
+            impressionData: false,
+        },
+    ];
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap,
+        impressionDataAll: true,
+    };
+    const client = new UnleashClient(config);
+    client.start();
+
+    client.on(EVENTS.READY, () => {
+        const isEnabled = client.isEnabled('unknown');
+        expect(isEnabled).toBe(true);
+    });
+
+    client.on(EVENTS.IMPRESSION, (event: any) => {
+        expect(event.featureName).toBe('unknown');
+        expect(event.eventType).toBe('isEnabled');
+        expect(event.enabled).toBe(false);
+        expect(event.impressionData).toBe(undefined);
+        client.stop();
+        done();
+    });
+});
+
 test('Should call getVariant event when impressionData is false and impressionDataAll is true', (done) => {
     const bootstrap = [
         {
@@ -1186,7 +1261,7 @@ test('Should call getVariant event when impressionData is false and impressionDa
     client.on(EVENTS.IMPRESSION, (event: any) => {
         expect(event.featureName).toBe('impression-variant');
         expect(event.eventType).toBe('getVariant');
-        expect(event.impressionData).toBe(false);
+        expect(event.impressionData).toBe(undefined);
         client.stop();
         done();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,8 @@ export class UnleashClient extends TinyEmitter {
                 this.context,
                 enabled,
                 toggleName,
-                toggle?.impressionData || false,
-                IMPRESSION_EVENTS.IS_ENABLED
+                IMPRESSION_EVENTS.IS_ENABLED,
+                toggle?.impressionData || undefined,
             );
             this.emit(EVENTS.IMPRESSION, event);
         }
@@ -213,8 +213,8 @@ export class UnleashClient extends TinyEmitter {
                 this.context,
                 enabled,
                 toggleName,
-                toggle?.impressionData || false,
                 IMPRESSION_EVENTS.GET_VARIANT,
+                toggle?.impressionData || undefined,
                 variant.name,
             );
             this.emit(EVENTS.IMPRESSION, event);


### PR DESCRIPTION
Make it possible to enable impression data for all isEnabled / getVariant calls. This PR also introduces a "impressionData" flag to the event itself, so the implementer can choose to discard events when we do not know whether impressionData is enabled for this toggle.

The reason we need this override in the proxy-sdk is that it simply does not know anything about disabled toggles (by design, to not leak information to the end-user about toggles). This makes it impossible to get impression data for disabled toggles, as they are not exposed to the frontend at all.

**Todo:**

- [x]  Add documentation for the new config property
- [x]  Add unit tests forimpressionDataAll