### PR TITLE
Feat/store etag

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,24 @@ test('Should perform an initial fetch', async () => {
     expect(isEnabled).toBe(true);
 });
 
+test('Should perform an initial fetch as POST', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(data));
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'webAsPOST',
+        usePOSTrequests: true,
+    };
+    const client = new UnleashClient(config);
+    await client.start();
+    
+    const request = getTypeSafeRequest(fetchMock, 0);
+    const body = JSON.parse(request.body as string);
+
+    expect(request.method).toBe('POST');
+    expect(body.context.appName).toBe('webAsPOST');
+});
+
 test('Should have correct variant', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
     const config: IConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ interface IConfig extends IStaticContext {
     headerName?: string;
     customHeaders?: Record<string, string>;
     impressionDataAll?: boolean;
+    usePOSTrequests?: boolean;
 }
 
 interface IVariant {
@@ -106,6 +107,7 @@ export class UnleashClient extends TinyEmitter {
     private eventsHandler: EventsHandler;
     private customHeaders: Record<string, string>;
     private readyEventEmitted = false;
+    private usePOSTrequests = false;
 
     constructor({
         storageProvider,
@@ -124,6 +126,7 @@ export class UnleashClient extends TinyEmitter {
         headerName = 'Authorization',
         customHeaders = {},
         impressionDataAll = false,
+        usePOSTrequests = false,
     }: IConfig) {
         super();
         // Validations
@@ -146,6 +149,7 @@ export class UnleashClient extends TinyEmitter {
         this.storage = storageProvider || new LocalStorageProvider();
         this.refreshInterval = disableRefresh ? 0 : refreshInterval * 1000;
         this.context = { appName, environment, ...context };
+        this.usePOSTrequests = usePOSTrequests;
         this.ready = new Promise((resolve) => {
             this.init()
                 .then(resolve)
@@ -335,33 +339,41 @@ export class UnleashClient extends TinyEmitter {
     private async fetchToggles() {
         if (this.fetch) {
             try {
-                const context = this.context;
-                const urlWithQuery = new URL(this.url.toString());
-                // Add context information to url search params. If the properties
-                // object is included in the context, flatten it into the search params
-                // e.g. /?...&property.param1=param1Value&property.param2=param2Value
-                Object.entries(context)
-                    .filter(notNullOrUndefined)
-                    .forEach(([contextKey, contextValue]) => {
-                        if (contextKey === 'properties' && contextValue) {
-                            Object.entries<string>(contextValue)
-                                .filter(notNullOrUndefined)
-                                .forEach(([propertyKey, propertyValue]) =>
-                                    urlWithQuery.searchParams.append(
-                                        `properties[${propertyKey}]`,
-                                        propertyValue
-                                    )
+
+                let url = this.url.toString();
+                if(!this.usePOSTrequests) {
+                    const context = this.context;
+                    const urlWithQuery = new URL(this.url.toString());
+                    // Add context information to url search params. If the properties
+                    // object is included in the context, flatten it into the search params
+                    // e.g. /?...&property.param1=param1Value&property.param2=param2Value
+                    Object.entries(context)
+                        .filter(notNullOrUndefined)
+                        .forEach(([contextKey, contextValue]) => {
+                            if (contextKey === 'properties' && contextValue) {
+                                Object.entries<string>(contextValue)
+                                    .filter(notNullOrUndefined)
+                                    .forEach(([propertyKey, propertyValue]) =>
+                                        urlWithQuery.searchParams.append(
+                                            `properties[${propertyKey}]`,
+                                            propertyValue
+                                        )
+                                    );
+                            } else {
+                                urlWithQuery.searchParams.append(
+                                    contextKey,
+                                    contextValue
                                 );
-                        } else {
-                            urlWithQuery.searchParams.append(
-                                contextKey,
-                                contextValue
-                            );
-                        }
-                    });
-                const response = await this.fetch(urlWithQuery.toString(), {
+                            }
+                        });
+                    url = urlWithQuery.toString();
+                }
+                
+                const response = await this.fetch(url, {
+                    method: this.usePOSTrequests ? 'POST' : 'GET',
                     cache: 'no-cache',
                     headers: this.getHeaders(),
+                    body: this.usePOSTrequests ? JSON.stringify({context: this.context}) : undefined,
                 });
                 if (response.ok && response.status !== 304) {
                     this.etag = response.headers.get('ETag') || '';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,2 +1,32 @@
+import { IContext } from '.';
+
 export const notNullOrUndefined = ([, value]: [string, string]) =>
     value !== undefined && value !== null;
+
+
+export const urlWithContextAsQuery = (url: URL, context: IContext) => {
+    const urlWithQuery = new URL(url.toString());
+    // Add context information to url search params. If the properties
+    // object is included in the context, flatten it into the search params
+    // e.g. /?...&property.param1=param1Value&property.param2=param2Value
+    Object.entries(context)
+        .filter(notNullOrUndefined)
+        .forEach(([contextKey, contextValue]) => {
+            if (contextKey === 'properties' && contextValue) {
+                Object.entries<string>(contextValue)
+                    .filter(notNullOrUndefined)
+                    .forEach(([propertyKey, propertyValue]) =>
+                        urlWithQuery.searchParams.append(
+                            `properties[${propertyKey}]`,
+                            propertyValue
+                        )
+                    );
+            } else {
+                urlWithQuery.searchParams.append(
+                    contextKey,
+                    contextValue
+                );
+            }
+        });
+    return urlWithQuery;
+}


### PR DESCRIPTION
Store etag in localStorage would make sure that also the initial fetch can be 304 if the user already has the latest toggles in localStorage. Builds on top of [feat/POST-fetching](https://github.com/Unleash/unleash-proxy-client-js/tree/feat/POST-fetching)

I think this is a good idea?