### PR TITLE
fix: revert to commonjs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,14 @@
-export default {
-    roots: ['<rootDir>/src'],
-    transform: {
-        '^.+\\.tsx?$': 'ts-jest',
+module.exports = {
+    "roots": [
+        "<rootDir>/src"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
     },
-    automock: false,
-    setupFiles: ['./setupJest.js', 'jest-localstorage-mock'],
-    testEnvironment: 'jsdom',
-};
+    "automock": false,
+    "setupFiles": [
+        "./setupJest.js",
+        "jest-localstorage-mock"
+    ],
+    "testEnvironment": "jsdom"
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A browser client that can be used together with the unleash-proxy.",
-  "type": "module",
   "main": "./build/cjs/index.js",
   "types": "./build/cjs/index.d.ts",
   "browser": "./build/main.min.js",


### PR DESCRIPTION
Fixes https://github.com/Unleash/unleash-proxy-client-js/issues/173

We are not ready to support ESM yet. Reverting back to CommonJS, so we don't break build.