### PR TITLE
fix: sourcemap path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,7 @@
     //"allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    "sourceRoot": "../src",                   /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */


### PR DESCRIPTION
## About the changes
Paths to some source files are incorrect
https://sourcemaps.io/report/1698835631581_https%3A%2F%2Funpkg.com%2Funleash-proxy-client%403.0.0%2Fbuild%2Fmain.esm.js

Similar issue: https://github.com/ezolenko/rollup-plugin-typescript2/issues/407#issuecomment-1200016679

Closes #178