### PR TITLE
feat: fire event when error is present and http call succeeds

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1369,3 +1369,26 @@ test('Should be able to configure UnleashClient with a URL instance', () => {
     const client = new UnleashClient(config);
     expect(client).toHaveProperty('url', url);
 });
+
+test('Should emit SUCCESSFUL when networkError is HttpError and status is less than 400', (done) => {
+    const data = { status: 200 }; // replace with the actual data you want to test
+    fetchMock.mockResponseOnce(JSON.stringify(data), { status: 200 });
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+
+    const client = new UnleashClient(config);
+    // @ts-ignore - Private method
+    client.networkError = 'HttpError'; // set networkError to 'HttpError'
+    client.start();
+
+    client.on(EVENTS.POST_ERROR_SUCCESS, () => {
+        // @ts-ignore - Private method
+        expect(client.networkError).toBe(null);
+        client.stop();
+        done();
+    });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1381,13 +1381,13 @@ test('Should emit SUCCESSFUL when networkError is HttpError and status is less t
     };
 
     const client = new UnleashClient(config);
-    // @ts-ignore - Private method
-    client.networkError = 'HttpError'; // set networkError to 'HttpError'
+    // @ts-ignore - Private method by design, but we want to access it in tests
+    client.sdkError = 'SdkError'; // set networkError to 'HttpError'
     client.start();
 
     client.on(EVENTS.POST_ERROR_SUCCESS, () => {
-        // @ts-ignore - Private method
-        expect(client.networkError).toBe(null);
+        // @ts-ignore - Private method bu desogm. but we want to access it in tests
+        expect(client.sdkError).toBe(null);
         client.stop();
         done();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export class UnleashClient extends TinyEmitter {
     private customHeaders: Record<string, string>;
     private readyEventEmitted = false;
     private usePOSTrequests = false;
-    private networkError: null | string;
+    private sdkError: null | 'SdkError';
 
     constructor({
         storageProvider,
@@ -157,6 +157,7 @@ export class UnleashClient extends TinyEmitter {
                 .then(resolve)
                 .catch((error) => {
                     console.error(error);
+                    this.sdkError = 'SdkError';
                     this.emit(EVENTS.ERROR, error);
                     resolve();
                 });
@@ -172,7 +173,7 @@ export class UnleashClient extends TinyEmitter {
         this.bootstrap =
             bootstrap && bootstrap.length > 0 ? bootstrap : undefined;
         this.bootstrapOverride = bootstrapOverride;
-        this.networkError = null;
+        this.sdkError = null;
 
         this.metrics = new Metrics({
             onError: this.emit.bind(this, EVENTS.ERROR),
@@ -367,8 +368,8 @@ export class UnleashClient extends TinyEmitter {
                     body,
                 });
 
-                if (this.networkError === 'HttpError' && response.status < 400) {
-                    this.networkError = null;
+                if (this.sdkError === 'SdkError' && response.status < 400) {
+                    this.sdkError = null;
                     this.emit(EVENTS.POST_ERROR_SUCCESS);
                 }
 
@@ -385,7 +386,7 @@ export class UnleashClient extends TinyEmitter {
                     console.error(
                         'Unleash: Fetching feature toggles did not have an ok response'
                     );
-                    this.networkError = 'HttpError';
+                    this.sdkError = 'SdkError';
                     this.emit(EVENTS.ERROR, {
                         type: 'HttpError',
                         code: response.status,
@@ -393,6 +394,7 @@ export class UnleashClient extends TinyEmitter {
                 }
             } catch (e) {
                 console.error('Unleash: unable to fetch feature toggles', e);
+                this.sdkError = 'SdkError'
                 this.emit(EVENTS.ERROR, e);
             }
         }


### PR DESCRIPTION
This PR adds a new event that fires when an error was recorded and the subsequent HTTP call is successful.

### Why
Our React Proxy SDK will set an error based on the error event fired from this SDK when the HTTP call fails. Without this event we have no way to effectively reset this error, because the only event that is fired consistently is the UPDATE event, which is only fired when the response is not 304. This does not cover the case when you intermittently lose connection and the next call succeeds with 304.

### How
We keep track of the networkError internally in the SDK. When the state of the SDK HTTP call errors we record the error. If the error is set, and the call is successful we will emit a POST_ERROR_SUCCESS event that will allow subscribers to clear out stale errors.