### PR TITLE
feat: fire event when error is present and http call succeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ unleash.on('update', () => {
 - **initialized** - emitted after the SDK has read local cached data in the storageProvider. 
 - **ready** - emitted after the SDK has successfully started and performed the initial fetch towards the Unleash Proxy. 
 - **update** - emitted every time the Unleash Proxy return a new feature toggle configuration. The SDK will emit this event as part of the initial fetch from the SDK.  
+- **recovered** - emitted when the SDK has recovered from an error. This event will only be emitted if the SDK has previously emitted an error.
+- **sent** - emitted when the SDK has successfully sent metrics to Unleash.
 
 > PS! Please remember that you should always register your event listeners before your call `unleash.start()`. If you register them after you have started the SDK you risk loosing important events. 
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1574,7 +1574,7 @@ test('Should report metrics', async () => {
     client.stop();
 });
 
-test('Should emit POST_ERROR_SUCCESS when networkError is HttpError and status is less than 400', (done) => {
+test('Should emit RECOVERED event when sdkStatus is error and status is less than 400', (done) => {
     const data = { status: 200 }; // replace with the actual data you want to test
     fetchMock.mockResponseOnce(JSON.stringify(data), { status: 200 });
 
@@ -1587,13 +1587,13 @@ test('Should emit POST_ERROR_SUCCESS when networkError is HttpError and status i
     const client = new UnleashClient(config);
     // eslint-disable-next-line
     // @ts-ignore - Private method by design, but we want to access it in tests
-    client.sdkError = 'SdkError';
+    client.sdkState = 'error';
     client.start();
 
-    client.on(EVENTS.POST_ERROR_SUCCESS, () => {
+    client.on(EVENTS.RECOVERED, () => {
         // eslint-disable-next-line
         // @ts-ignore - Private method by design. but we want to access it in tests
-        expect(client.sdkError).toBe(null);
+        expect(client.sdkState).toBe('healthy');
         client.stop();
         done();
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1574,7 +1574,7 @@ test('Should report metrics', async () => {
     client.stop();
 });
 
-test('Should emit SUCCESSFUL when networkError is HttpError and status is less than 400', (done) => {
+test('Should emit POST_ERROR_SUCCESS when networkError is HttpError and status is less than 400', (done) => {
     const data = { status: 200 }; // replace with the actual data you want to test
     fetchMock.mockResponseOnce(JSON.stringify(data), { status: 200 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1585,12 +1585,14 @@ test('Should emit POST_ERROR_SUCCESS when networkError is HttpError and status i
     };
 
     const client = new UnleashClient(config);
+    // eslint-disable-next-line
     // @ts-ignore - Private method by design, but we want to access it in tests
     client.sdkError = 'SdkError'; // set networkError to 'HttpError'
     client.start();
 
     client.on(EVENTS.POST_ERROR_SUCCESS, () => {
-        // @ts-ignore - Private method bu desogm. but we want to access it in tests
+        // eslint-disable-next-line
+        // @ts-ignore - Private method by design. but we want to access it in tests
         expect(client.sdkError).toBe(null);
         client.stop();
         done();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1585,14 +1585,43 @@ test('Should emit RECOVERED event when sdkStatus is error and status is less tha
     };
 
     const client = new UnleashClient(config);
-    // eslint-disable-next-line
-    // @ts-ignore - Private method by design, but we want to access it in tests
-    client.sdkState = 'error';
+
     client.start();
+
+    client.on(EVENTS.INIT, () => {
+        // Set error after the SDK has moved through the sdk states internally
+        // eslint-disable-next-line
+        // @ts-ignore - Private method by design, but we want to access it in tests
+        client.sdkState = 'error';
+    });
+
 
     client.on(EVENTS.RECOVERED, () => {
         // eslint-disable-next-line
         // @ts-ignore - Private method by design. but we want to access it in tests
+        expect(client.sdkState).toBe('healthy');
+        client.stop();
+        done();
+    });
+});
+
+test('Should set sdkState to healthy when client is started', (done) => {
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+
+    const client = new UnleashClient(config);
+    // eslint-disable-next-line
+    // @ts-ignore - Private method by design, but we want to access it in tests
+    expect(client.sdkState).toBe('initializing');
+
+    client.start();
+
+    client.on(EVENTS.INIT, () => {
+        // eslint-disable-next-line
+        // @ts-ignore - Private method by design, but we want to access it in tests
         expect(client.sdkState).toBe('healthy');
         client.stop();
         done();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1573,3 +1573,26 @@ test('Should report metrics', async () => {
     });
     client.stop();
 });
+
+test('Should emit SUCCESSFUL when networkError is HttpError and status is less than 400', (done) => {
+    const data = { status: 200 }; // replace with the actual data you want to test
+    fetchMock.mockResponseOnce(JSON.stringify(data), { status: 200 });
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+
+    const client = new UnleashClient(config);
+    // @ts-ignore - Private method by design, but we want to access it in tests
+    client.sdkError = 'SdkError'; // set networkError to 'HttpError'
+    client.start();
+
+    client.on(EVENTS.POST_ERROR_SUCCESS, () => {
+        // @ts-ignore - Private method bu desogm. but we want to access it in tests
+        expect(client.sdkError).toBe(null);
+        client.stop();
+        done();
+    });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1595,7 +1595,6 @@ test('Should emit RECOVERED event when sdkStatus is error and status is less tha
         client.sdkState = 'error';
     });
 
-
     client.on(EVENTS.RECOVERED, () => {
         // eslint-disable-next-line
         // @ts-ignore - Private method by design. but we want to access it in tests

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1587,7 +1587,7 @@ test('Should emit POST_ERROR_SUCCESS when networkError is HttpError and status i
     const client = new UnleashClient(config);
     // eslint-disable-next-line
     // @ts-ignore - Private method by design, but we want to access it in tests
-    client.sdkError = 'SdkError'; // set networkError to 'HttpError'
+    client.sdkError = 'SdkError';
     client.start();
 
     client.on(EVENTS.POST_ERROR_SUCCESS, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export const EVENTS = {
     UPDATE: 'update',
     IMPRESSION: 'impression',
     SENT: 'sent',
-    POST_ERROR_SUCCESS: 'postErrorSuccess'
+    POST_ERROR_SUCCESS: 'postErrorSuccess',
 };
 
 const IMPRESSION_EVENTS = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,9 +328,10 @@ export class UnleashClient extends TinyEmitter {
         ) {
             await this.storage.save(storeKey, this.bootstrap);
             this.toggles = this.bootstrap;
-            this.sdkState = 'healthy';
             this.emit(EVENTS.READY);
         }
+        
+        this.sdkState = 'healthy';
         this.emit(EVENTS.INIT);
     }
 
@@ -432,6 +433,10 @@ export class UnleashClient extends TinyEmitter {
                     this.etag = response.headers.get('ETag') || '';
                     const data = await response.json();
                     await this.storeToggles(data.toggles);
+
+                    if (this.sdkState !== 'healthy') {
+                        this.sdkState = 'healthy';
+                    }
 
                     if (!this.bootstrap && !this.readyEventEmitted) {
                         this.emit(EVENTS.READY);

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,6 @@ export class UnleashClient extends TinyEmitter {
                     body,
                     signal,
                 });
-
                 if (this.sdkState === 'error' && response.status < 400) {
                     this.sdkState = 'healthy';
                     this.emit(EVENTS.RECOVERED);

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const defaultVariant: IVariant = {
 };
 const storeKey = 'repo';
 
-type SdkState = 'initializing' | 'healthy' | 'error'
+type SdkState = 'initializing' | 'healthy' | 'error';
 
 export const resolveFetch = () => {
     try {
@@ -330,7 +330,7 @@ export class UnleashClient extends TinyEmitter {
             this.toggles = this.bootstrap;
             this.emit(EVENTS.READY);
         }
-        
+
         this.sdkState = 'healthy';
         this.emit(EVENTS.INIT);
     }


### PR DESCRIPTION
This PR adds a new event that fires when an error was recorded and the subsequent HTTP call is successful.

### Why
Our React Proxy SDK will set an error based on the error event fired from this SDK when the HTTP call fails. Without this event we have no way to effectively reset this error, because the only event that is fired consistently is the UPDATE event, which is only fired when the response is not 304. This does not cover the case when you intermittently lose connection and the next call succeeds with 304.

### How
We keep track of the sdkState internally in the SDK. When the HTTP calls error we change the state of the SDK to be in an error state. If the internal SDK state is set to error, and the HTTP call is successful we will emit a RECOVERED event that will allow subscribers to clear out stale errors and set the sdkState back to 'healthy'.