### PR TITLE
fix: don't send empty If-None-Match header

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -703,9 +703,7 @@ test('Should include etag in second request', async () => {
     const firstRequest = getTypeSafeRequest(fetchMock, 0);
     const secondRequest = getTypeSafeRequest(fetchMock, 1);
 
-    expect(firstRequest.headers).toMatchObject({
-        'If-None-Match': '',
-    });
+    expect(firstRequest.headers).toMatchObject({});
     expect(secondRequest.headers).toMatchObject({
         'If-None-Match': etag,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,14 +365,14 @@ export class UnleashClient extends TinyEmitter {
     private async resolveSessionId(): Promise<string> {
         if (this.context.sessionId) {
             return this.context.sessionId;
-        } else {
-            let sessionId = await this.storage.get('sessionId');
-            if (!sessionId) {
-                sessionId = Math.floor(Math.random() * 1_000_000_000);
-                await this.storage.save('sessionId', sessionId);
-            }
-            return sessionId;
         }
+
+        let sessionId = await this.storage.get('sessionId');
+        if (!sessionId) {
+            sessionId = Math.floor(Math.random() * 1_000_000_000);
+            await this.storage.save('sessionId', sessionId);
+        }
+        return sessionId;
     }
 
     private getHeaders() {
@@ -380,8 +380,10 @@ export class UnleashClient extends TinyEmitter {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'If-None-Match': this.etag,
         };
+        if (this.etag) {
+            headers['If-None-Match'] = this.etag;
+        }
         Object.entries(this.customHeaders)
             .filter(notNullOrUndefined)
             .forEach(([name, value]) => (headers[name] = value));


### PR DESCRIPTION
## About the changes

Our network firewall blocks the requests made, because the header [If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) is sent with an empty value, which is considered a violation.

According to MDN's doc:
<img width="438" alt="image" src="https://github.com/Unleash/unleash-proxy-client-js/assets/1692136/ef66a67f-8b0f-4c6b-89ab-d43736ffd0eb">

*So I removed it when empty to match the spec ;)