### PR TITLE
fix: don't send 'If-None-Match' header for empty etag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,8 +380,13 @@ export class UnleashClient extends TinyEmitter {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'If-None-Match': this.etag,
         };
+
+        // only add etag, if it's not an empty string
+        if (this.etag) {
+            headers['If-None-Match'] = this.etag;
+        }
+
         Object.entries(this.customHeaders)
             .filter(notNullOrUndefined)
             .forEach(([name, value]) => (headers[name] = value));


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #189 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
`src/index.ts`


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Should this only be applied to this `If-None-Match` header, or should maybe the `notNullOrUndefined` function in `./utils.ts` be also changed to `notNullOrUndefinedOrEmptyString`?
