### PR TITLE
feat: add removeContextField method

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1127,6 +1127,42 @@ test('Should override userId via setContextField', async () => {
     expect(context.userId).toBe(userId);
 });
 
+test('Should allow to remove context defined field via removeContextField', async () => {
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        context: { userId: 'old' },
+    };
+    const client = new UnleashClient(config);
+    client.removeContextField('userId');
+    const context = client.getContext();
+    expect(context.userId).not.toBeDefined();
+});
+
+test('Should allow to remove context property field via removeContextField', async () => {
+    const propertyToDelete = 'property1';
+    const propertyToKeep = 'property2';
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        context: {
+            userId: 'userId',
+            properties: {
+                [propertyToDelete]: 'value1',
+                [propertyToKeep]: 'value2',
+            },
+        },
+    };
+    const client = new UnleashClient(config);
+    client.removeContextField(propertyToDelete);
+    const context = client.getContext();
+    expect(context.userId).toBeDefined();
+    expect(context.properties?.[propertyToDelete]).not.toBeDefined();
+    expect(context.properties?.[propertyToKeep]).toBeDefined();
+});
+
 test('Initializing client twice should show a console warning', async () => {
     console.error = jest.fn();
     const config: IConfig = {


### PR DESCRIPTION
## About the changes
Adding a `removeContextField`, because `setContextField` accepts only `string` and currently removing a field means manipulation with `getContext()`'s result to turn it to `IMutableContext` first or the console warn will be thrown.

Also `setContextField` was already lagging behind the `updateContext` in how it fetches the data after an update. Someone changed `updateContext` but not `setContextField`, so I moved that code to `updateToggles` call to be able to reuse it. Lmk what you think.

### Important files
- index.ts
- index.test.ts

## Discussion points
- extra method vs making `setContextField` accepting `undefined` as a value to remove it
- moving the re-fetch logic to another method, what should be a name of it - `updateToggles` `refetchToggles` .. ?
- also `setContextField` was not waiting for the end of the update while `updateToggles` does. Should `setContextField` be async as well?