### PR TITLE
fix: adds content type only on post method

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,6 +60,9 @@ test('Should perform an initial fetch as POST', async () => {
 
     expect(request.method).toBe('POST');
     expect(body.context.appName).toBe('webAsPOST');
+    expect(request.headers).toMatchObject({
+        'Content-Type': 'application/json',
+    });
 });
 
 test('Should perform an initial fetch as GET', async () => {
@@ -75,6 +78,9 @@ test('Should perform an initial fetch as GET', async () => {
     const request = getTypeSafeRequest(fetchMock, 0);
 
     expect(request.method).toBe('GET');
+    expect(request.headers).not.toMatchObject({
+        'Content-Type': 'application/json',
+    });
 });
 
 test('Should have correct variant', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -400,11 +400,14 @@ export class UnleashClient extends TinyEmitter {
     }
 
     private getHeaders() {
+        const isPOST = this.usePOSTrequests;
         const headers = {
             [this.headerName]: this.clientKey,
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
+            Accept: 'application/json'
         };
+        if (isPOST){
+            headers['Content-Type'] = 'application/json';
+        }
         if (this.etag) {
             headers['If-None-Match'] = this.etag;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,9 +403,9 @@ export class UnleashClient extends TinyEmitter {
         const isPOST = this.usePOSTrequests;
         const headers = {
             [this.headerName]: this.clientKey,
-            Accept: 'application/json'
+            Accept: 'application/json',
         };
-        if (isPOST){
+        if (isPOST) {
             headers['Content-Type'] = 'application/json';
         }
         if (this.etag) {


### PR DESCRIPTION
In sdk for set GET request adds content type in header but not necessary  and common waf unit block this request, i change code and set content type header adds only in POST request.

[Closes #197 ]
