### PR TITLE
Fix: ready not emitted when bootstrap is set and bootrstrapOverride is false

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1675,20 +1675,20 @@ describe('READY event emission', () => {
         clientKey: '12',
         appName: 'web',
         bootstrap: [
-        {
-            enabled: false,
-            name: 'test-frontend',
-            variant: { name: 'some-variant', enabled: false},
-            impressionData: false
-        },
-    ],
+            {
+                enabled: false,
+                name: 'test-frontend',
+                variant: { name: 'some-variant', enabled: false },
+                impressionData: false,
+            },
+        ],
         bootstrapOverride: false,
         fetch: async () => {
             return {
                 ok: true,
                 headers: new Map(),
                 async json() {
-                    return {  };
+                    return {};
                 },
             };
         },
@@ -1702,10 +1702,15 @@ describe('READY event emission', () => {
 
     test('should emit READY when response is OK and not 304, and conditions are met', async () => {
         // Mock a successful fetch response that is not 304
-        fetchMock.mockResponseOnce(JSON.stringify({ toggles: [{ feature: 'test-feature', enabled: true }] }), {
-            status: 200,
-            headers: { 'ETag': 'new-etag' }
-        });
+        fetchMock.mockResponseOnce(
+            JSON.stringify({
+                toggles: [{ feature: 'test-feature', enabled: true }],
+            }),
+            {
+                status: 200,
+                headers: { ETag: 'new-etag' },
+            }
+        );
 
         expect(client.emit).toHaveBeenCalledWith(EVENTS.READY);
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1666,3 +1666,48 @@ test('Should set sdkState to healthy when client is started', (done) => {
         done();
     });
 });
+
+describe('Response handling and READY event emission', () => {
+    let client: UnleashClient;
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap: [
+        {
+            enabled: false,
+            name: 'test-frontend',
+            variant: { name: 'some-variant', enabled: false},
+            impressionData: false
+        },
+    ],
+        bootstrapOverride: false,
+        fetch: async () => {
+            return {
+                ok: true,
+                headers: new Map(),
+                async json() {
+                    return {  };
+                },
+            };
+        },
+    };
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        client = new UnleashClient(config);
+        jest.spyOn(client, 'emit');
+    });
+
+    test('should emit READY when response is OK and not 304, and conditions are met', async () => {
+        // Mock a successful fetch response that is not 304
+        fetchMock.mockResponseOnce(JSON.stringify({ toggles: [{ feature: 'test-feature', enabled: true }] }), {
+            status: 200,
+            headers: { 'ETag': 'new-etag' }
+        });
+
+        // Check that the toggles are stored, SDK state is healthy, and READY is emitted
+        expect(client.emit).toHaveBeenCalledWith(EVENTS.READY);
+    });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1667,7 +1667,7 @@ test('Should set sdkState to healthy when client is started', (done) => {
     });
 });
 
-describe('Response handling and READY event emission', () => {
+describe('READY event emission', () => {
     let client: UnleashClient;
 
     const config: IConfig = {
@@ -1707,7 +1707,6 @@ describe('Response handling and READY event emission', () => {
             headers: { 'ETag': 'new-etag' }
         });
 
-        // Check that the toggles are stored, SDK state is healthy, and READY is emitted
         expect(client.emit).toHaveBeenCalledWith(EVENTS.READY);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,7 @@ export class UnleashClient extends TinyEmitter {
                         this.sdkState = 'healthy';
                     }
 
-                    if (!this.bootstrap && !this.readyEventEmitted) {
+                    if ((!this.bootstrap || this.bootstrap && !this.bootstrapOverride) && !this.readyEventEmitted) {
                         this.emit(EVENTS.READY);
                         this.readyEventEmitted = true;
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,11 @@ export class UnleashClient extends TinyEmitter {
                         this.sdkState = 'healthy';
                     }
 
-                    if ((!this.bootstrap || this.bootstrap && !this.bootstrapOverride) && !this.readyEventEmitted) {
+                    if (
+                        (!this.bootstrap ||
+                            (this.bootstrap && !this.bootstrapOverride)) &&
+                        !this.readyEventEmitted
+                    ) {
                         this.emit(EVENTS.READY);
                         this.readyEventEmitted = true;
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,11 +466,7 @@ export class UnleashClient extends TinyEmitter {
                         this.sdkState = 'healthy';
                     }
 
-                    if (
-                        (!this.bootstrap ||
-                            (this.bootstrap && !this.bootstrapOverride)) &&
-                        !this.readyEventEmitted
-                    ) {
+                    if (!this.readyEventEmitted) {
                         this.emit(EVENTS.READY);
                         this.readyEventEmitted = true;
                     }


### PR DESCRIPTION
Fixes a bug where the Ready event was not emitted when bootstrap is defined and bootstrap override is false

Closes #199 