### PR TITLE
feat: prevent fetching toggles when they are up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The Unleash SDK takes the following options:
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used if it is not `null` or `undefined`. `customHeaders` values that are `null` or `undefined` will be ignored. |
 | impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
 | environment | no | `default` | Sets the `environment` option of the [Unleash context](https://docs.getunleash.io/reference/unleash-context). This does **not** affect the SDK's [Unleash environment](https://docs.getunleash.io/reference/environments). |
-| togglesStorageTTL   | no | `0` | How much time (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched again. If set to 0 will disable checking for expiration and considered always expired                 |
+| togglesStorageTTL   | no | `0` | How long (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched again. If set to 0 will disable expiration checking and will be considered always expired.                 |
 
 ### Listen for updates via the EventEmitter
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ if (variant.name === 'blue') {
 
 #### Updating the Unleash context
 
-The [Unleash context](https://docs.getunleash.io/reference/unleash-context) is used to evaluate features against attributes of a the current user. To update and configure the Unleash context in this SDK, use the `updateContext` and `setContextField` methods.
+The [Unleash context](https://docs.getunleash.io/reference/unleash-context) is used to evaluate features against attributes of a the current user. To update and configure the Unleash context in this SDK, use the `updateContext`, `setContextField` and `removeContextField` methods.
 
 The context you set in your app will be passed along to the Unleash proxy or the front-end API as query parameters for feature evaluation.
 
@@ -101,6 +101,14 @@ The `setContextField` method only acts on the property that you choose. It does 
 unleash.updateContext({ userId: '1233' });
 
 unleash.setContextField('userId', '4141');
+```
+
+The `removeContextField` method only acts on the property that you choose. It does not affect any other properties of the Unleash context.
+
+```js
+unleash.updateContext({ userId: '1233', sessionId: 'sessionNotAffected' });
+
+unleash.removeContextField('userId');
 ```
 
 ### Available options

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The Unleash SDK takes the following options:
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used if it is not `null` or `undefined`. `customHeaders` values that are `null` or `undefined` will be ignored. |
 | impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
 | environment | no | `default` | Sets the `environment` option of the [Unleash context](https://docs.getunleash.io/reference/unleash-context). This does **not** affect the SDK's [Unleash environment](https://docs.getunleash.io/reference/environments). |
+| togglesStorageTTL   | no | `0` | How much time, in seconds, the toggles are considered valid and should not be fetched again. If set to 0 will disable checking for expiration and considered always expired                 |
 
 ### Listen for updates via the EventEmitter
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The Unleash SDK takes the following options:
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used if it is not `null` or `undefined`. `customHeaders` values that are `null` or `undefined` will be ignored. |
 | impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
 | environment | no | `default` | Sets the `environment` option of the [Unleash context](https://docs.getunleash.io/reference/unleash-context). This does **not** affect the SDK's [Unleash environment](https://docs.getunleash.io/reference/environments). |
-| togglesStorageTTL   | no | `0` | How much time, in seconds, the toggles are considered valid and should not be fetched again. If set to 0 will disable checking for expiration and considered always expired                 |
+| togglesStorageTTL   | no | `0` | How much time (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched again. If set to 0 will disable checking for expiration and considered always expired                 |
 
 ### Listen for updates via the EventEmitter
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The Unleash SDK takes the following options:
 | customHeaders     | no| `{}` | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used if it is not `null` or `undefined`. `customHeaders` values that are `null` or `undefined` will be ignored. |
 | impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
 | environment | no | `default` | Sets the `environment` option of the [Unleash context](https://docs.getunleash.io/reference/unleash-context). This does **not** affect the SDK's [Unleash environment](https://docs.getunleash.io/reference/environments). |
-| togglesStorageTTL   | no | `0` | How long (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched again. If set to 0 will disable expiration checking and will be considered always expired.                 |
+| togglesStorageTTL   | no | `0` | How long (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched on start. If set to 0 will disable expiration checking and will be considered always expired.                 |
 
 ### Listen for updates via the EventEmitter
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,19 @@
   "version": "3.3.2",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./build/index.cjs",
+  "types": "./build/cjs/index.d.ts",	
+  "browser": "./build/main.min.js",	
+  "module": "./build/main.esm.js",	
+  "exports": {	
+    ".": {	
+      "import": "./build/main.esm.js",	
+      "node": "./build/index.cjs",	
+      "require": "./build/index.cjs",	
+      "types": "./build/cjs/index.d.ts",	
+      "default": "./build/main.min.js"	
+    }	
+  },
   "files": [
     "build",
     "examples",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",
-  "types": "./build/cjs/index.d.ts",	
-  "browser": "./build/main.min.js",	
-  "module": "./build/main.esm.js",	
-  "exports": {	
-    ".": {	
-      "import": "./build/main.esm.js",	
-      "node": "./build/index.cjs",	
-      "require": "./build/index.cjs",	
-      "types": "./build/cjs/index.d.ts",	
-      "default": "./build/main.min.js"	
-    }	
+  "types": "./build/cjs/index.d.ts",
+  "browser": "./build/main.min.js",
+  "module": "./build/main.esm.js",
+  "exports": {
+    ".": {
+      "import": "./build/main.esm.js",
+      "node": "./build/index.cjs",
+      "require": "./build/index.cjs",
+      "types": "./build/cjs/index.d.ts",
+      "default": "./build/main.min.js"
+    }
   },
   "files": [
     "build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.4.0-beta.0",
+  "version": "3.3.2",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/package.json
+++ b/package.json
@@ -3,19 +3,7 @@
   "version": "3.3.2",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
-  "main": "./build/index.cjs",
-  "types": "./build/cjs/index.d.ts",
-  "browser": "./build/main.min.js",
-  "module": "./build/main.esm.js",
-  "exports": {
-    ".": {
-      "import": "./build/main.esm.js",
-      "node": "./build/index.cjs",
-      "require": "./build/index.cjs",
-      "types": "./build/cjs/index.d.ts",
-      "default": "./build/main.min.js"
-    }
-  },
+  "main": "./src/index.ts",
   "files": [
     "build",
     "examples",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.3.1",
+  "version": "3.4.0-beta.0",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-proxy-client",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "description": "A browser client that can be used together with the unleash-proxy.",
   "type": "module",
   "main": "./build/index.cjs",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -703,9 +703,7 @@ test('Should include etag in second request', async () => {
     const firstRequest = getTypeSafeRequest(fetchMock, 0);
     const secondRequest = getTypeSafeRequest(fetchMock, 1);
 
-    expect(firstRequest.headers).toMatchObject({
-        'If-None-Match': '',
-    });
+    expect(firstRequest.headers).toMatchObject({});
     expect(secondRequest.headers).toMatchObject({
         'If-None-Match': etag,
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,6 +60,9 @@ test('Should perform an initial fetch as POST', async () => {
 
     expect(request.method).toBe('POST');
     expect(body.context.appName).toBe('webAsPOST');
+    expect(request.headers).toMatchObject({
+        'Content-Type': 'application/json',
+    });
 });
 
 test('Should perform an initial fetch as GET', async () => {
@@ -75,6 +78,9 @@ test('Should perform an initial fetch as GET', async () => {
     const request = getTypeSafeRequest(fetchMock, 0);
 
     expect(request.method).toBe('GET');
+    expect(request.headers).not.toMatchObject({
+        'Content-Type': 'application/json',
+    });
 });
 
 test('Should have correct variant', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -585,7 +585,10 @@ describe('handling last update flag storage', () => {
 
         const client = new UnleashClient(config);
         await client.start();
-        expect(saveSpy).toHaveBeenCalledWith('repoLastUpdateTimestamp', expect.any(Number));
+        expect(saveSpy).toHaveBeenCalledWith(
+            'repoLastUpdateTimestamp',
+            expect.any(Number)
+        );
         expect(saveSpy.mock.lastCall?.at(1)).toBeGreaterThanOrEqual(startTime);
     });
 
@@ -602,7 +605,10 @@ describe('handling last update flag storage', () => {
 
         const client = new UnleashClient(config);
         await client.start();
-        expect(saveSpy).toHaveBeenCalledWith('repoLastUpdateTimestamp', expect.any(Number));
+        expect(saveSpy).toHaveBeenCalledWith(
+            'repoLastUpdateTimestamp',
+            expect.any(Number)
+        );
         expect(saveSpy.mock.lastCall?.at(1)).toBeGreaterThanOrEqual(startTime);
     });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1571,9 +1571,21 @@ test('Should publish ready only when the first fetch was successful', async () =
         expect(readyCount).toEqual(1);
     });
 
+    let fetchCount = 0;
+
+    const fetchedPromise = new Promise<void>((resolve) => {
+        client.on(EVENTS.UPDATE, () => {
+            fetchCount++;
+            if (fetchCount === 2) {
+                resolve();
+            }
+        });
+    });
+
     jest.advanceTimersByTime(1001);
     jest.advanceTimersByTime(1001);
 
+    await fetchedPromise;
     expect(fetchMock).toHaveBeenCalledTimes(3);
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -570,11 +570,11 @@ describe('handling last update flag storage', () => {
         storageProvider = new Store();
         saveSpy = jest.spyOn(storageProvider, 'save');
     });
-    
+
     test('Should store last update flag when fetch is successful', async () => {
         const startTime = Date.now();
         fetchMock.mockResponseOnce(JSON.stringify(data));
-        
+
         const config: IConfig = {
             url: 'http://localhost/test',
             clientKey: '12',
@@ -591,14 +591,14 @@ describe('handling last update flag storage', () => {
     test('Should store last update flag when fetch is successful with 304 status', async () => {
         const startTime = Date.now();
         fetchMock.mockResponseOnce(JSON.stringify(data), { status: 304 });
-        
+
         const config: IConfig = {
             url: 'http://localhost/test',
             clientKey: '12',
             appName: 'web',
             storageProvider,
         };
-    
+
         const client = new UnleashClient(config);
         await client.start();
         expect(saveSpy).toHaveBeenCalledWith('lastUpdate', expect.any(Number));
@@ -607,14 +607,14 @@ describe('handling last update flag storage', () => {
 
     test('Should not store last update flag when fetch is not successful', async () => {
         fetchMock.mockResponseOnce('', { status: 500 });
-        
+
         const config: IConfig = {
             url: 'http://localhost/test',
             clientKey: '12',
             appName: 'web',
             storageProvider,
         };
-    
+
         const client = new UnleashClient(config);
         await client.start();
         expect(saveSpy).not.toHaveBeenCalledWith('lastUpdate', expect.any(Number));
@@ -1551,15 +1551,16 @@ test('Should emit impression events on getVariant calls when impressionData is f
 });
 
 test('Should publish ready only when the first fetch was successful', async () => {
+    expect.assertions(3);
     fetchMock.mockResponse(JSON.stringify(data));
     const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
         appName: 'web',
         refreshInterval: 1,
+        disableMetrics: true,
     };
     const client = new UnleashClient(config);
-    await client.start();
 
     let readyCount = 0;
 
@@ -1581,6 +1582,7 @@ test('Should publish ready only when the first fetch was successful', async () =
             }
         });
     });
+    await client.start();
 
     jest.advanceTimersByTime(1001);
     jest.advanceTimersByTime(1001);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1742,7 +1742,6 @@ test('Should set sdkState to healthy when client is started', (done) => {
     });
 });
 
-
 describe('READY event emission', () => {
     let client: UnleashClient;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -585,7 +585,7 @@ describe('handling last update flag storage', () => {
 
         const client = new UnleashClient(config);
         await client.start();
-        expect(saveSpy).toHaveBeenCalledWith('lastUpdate', expect.any(Number));
+        expect(saveSpy).toHaveBeenCalledWith('repoLastUpdateTimestamp', expect.any(Number));
         expect(saveSpy.mock.lastCall?.at(1)).toBeGreaterThanOrEqual(startTime);
     });
 
@@ -602,7 +602,7 @@ describe('handling last update flag storage', () => {
 
         const client = new UnleashClient(config);
         await client.start();
-        expect(saveSpy).toHaveBeenCalledWith('lastUpdate', expect.any(Number));
+        expect(saveSpy).toHaveBeenCalledWith('repoLastUpdateTimestamp', expect.any(Number));
         expect(saveSpy.mock.lastCall?.at(1)).toBeGreaterThanOrEqual(startTime);
     });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1882,4 +1882,22 @@ describe('handling togglesStorageTTL > 0', () => {
         await client.start();
         expect(readySpy).toHaveBeenCalledTimes(1);
     });
+
+    test('Should perform a fetch when context is updated, even if flags are up to date', async () => {
+        const config: IConfig = {
+            url: 'http://localhost/test',
+            clientKey: '12',
+            appName: 'web',
+            storageProvider: storage,
+            togglesStorageTTL: 60,
+        };
+        const client = new UnleashClient(config);
+        await client.start();
+        let isEnabled = client.isEnabled('simpleToggle');
+        expect(isEnabled).toBe(true);
+        await client.updateContext({ userId: '123' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        isEnabled = client.isEnabled('simpleToggle');
+        expect(isEnabled).toBe(false);
+    });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1082,6 +1082,19 @@ test('Should setContextField with remoteAddress', async () => {
     expect(context.remoteAddress).toBe(remoteAddress);
 });
 
+test('Should setContextField with currentTime', async () => {
+    const currentTime = '2022-01-22T13:00:00.000Z';
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    client.setContextField('currentTime', currentTime);
+    const context = client.getContext();
+    expect(context.currentTime).toBe(currentTime);
+});
+
 test('Should setContextField with custom property', async () => {
     const clientId = 'some-client-id-443';
     const config: IConfig = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1775,4 +1775,20 @@ describe('handling togglesStorageTTL', () => {
         client.stop();
         expect(fetchMock).toHaveBeenCalledTimes(0);
     });
+
+    test('Should send ready event when toggles are up to date and togglesStorageTTL > 0', async () => {
+        const config: IConfig = {
+            url: 'http://localhost/test',
+            clientKey: '12',
+            appName: 'web',
+            storageProvider: storage,
+            togglesStorageTTL: 60,
+        };
+        const client = new UnleashClient(config);
+
+        const readySpy = jest.fn();
+        client.on('ready', readySpy);
+        await client.start();
+        expect(readySpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -618,7 +618,10 @@ describe('handling last update flag storage', () => {
 
         const client = new UnleashClient(config);
         await client.start();
-        expect(saveSpy).not.toHaveBeenCalledWith('lastUpdate', expect.any(Number));
+        expect(saveSpy).not.toHaveBeenCalledWith(
+            'lastUpdate',
+            expect.any(Number)
+        );
     });
 });
 
@@ -1747,18 +1750,18 @@ describe('handling togglesStorageTTL > 0', () => {
         jest.useFakeTimers();
         jest.setSystemTime(fakeNow);
         storage = new InMemoryStorageProvider();
-        
-        fetchMock
-        .mockResponseOnce(JSON.stringify(data))
-        .mockResponseOnce(JSON.stringify({
-            "toggles": [
-              {
-                "name": "simpleToggle",
-                "enabled": false,
-                "impressionData": true
-              }
-            ]
-          }));
+
+        fetchMock.mockResponseOnce(JSON.stringify(data)).mockResponseOnce(
+            JSON.stringify({
+                toggles: [
+                    {
+                        name: 'simpleToggle',
+                        enabled: false,
+                        impressionData: true,
+                    },
+                ],
+            })
+        );
 
         const config: IConfig = {
             url: 'http://localhost/test',
@@ -1770,7 +1773,7 @@ describe('handling togglesStorageTTL > 0', () => {
         const client = new UnleashClient(config);
         await client.start();
         client.stop();
-    
+
         expect(fetchMock).toHaveBeenCalledTimes(1);
         fetchMock.mockClear();
     });
@@ -1842,7 +1845,7 @@ describe('handling togglesStorageTTL > 0', () => {
                     feature_enabled: true,
                 },
                 impressionData: true,
-            }
+            },
         ];
         const config: IConfig = {
             url: 'http://localhost/test',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1056,6 +1056,29 @@ test('Should setContextField with userId', async () => {
     expect(context.userId).toBe(userId);
 });
 
+test('Should removeContextField', async () => {
+    const userId = 'some-id-123';
+    const customValue = 'customValue';
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    client.setContextField('userId', userId);
+    client.setContextField('customField', customValue);
+
+    client.removeContextField('userId');
+    client.removeContextField('customField');
+    const context = client.getContext();
+
+    expect(context).toEqual({
+        appName: 'web',
+        environment: 'default',
+        properties: {},
+    });
+});
+
 test('Should setContextField with sessionId', async () => {
     const sessionId = 'some-session-id-123';
     const config: IConfig = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -581,7 +581,7 @@ describe('handling last update flag storage', () => {
             appName: 'web',
             storageProvider,
         };
-    
+
         const client = new UnleashClient(config);
         await client.start();
         expect(saveSpy).toHaveBeenCalledWith('lastUpdate', expect.any(Number));
@@ -1572,22 +1572,11 @@ test('Should publish ready only when the first fetch was successful', async () =
         expect(readyCount).toEqual(1);
     });
 
-    let fetchCount = 0;
-
-    const fetchedPromise = new Promise<void>((resolve) => {
-        client.on(EVENTS.UPDATE, () => {
-            fetchCount++;
-            if (fetchCount === 2) {
-                resolve();
-            }
-        });
-    });
     await client.start();
 
     jest.advanceTimersByTime(1001);
     jest.advanceTimersByTime(1001);
 
-    await fetchedPromise;
     expect(fetchMock).toHaveBeenCalledTimes(3);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,7 @@ export class UnleashClient extends TinyEmitter {
     }
 
     private isUpToDate() {
-        if (this.togglesStorageTTL <= 0 || this.toggles.length === 0) {
+        if (this.togglesStorageTTL <= 0) {
             return false;
         }
         const timestamp = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,14 +365,14 @@ export class UnleashClient extends TinyEmitter {
     private async resolveSessionId(): Promise<string> {
         if (this.context.sessionId) {
             return this.context.sessionId;
-        } else {
-            let sessionId = await this.storage.get('sessionId');
-            if (!sessionId) {
-                sessionId = Math.floor(Math.random() * 1_000_000_000);
-                await this.storage.save('sessionId', sessionId);
-            }
-            return sessionId;
         }
+
+        let sessionId = await this.storage.get('sessionId');
+        if (!sessionId) {
+            sessionId = Math.floor(Math.random() * 1_000_000_000);
+            await this.storage.save('sessionId', sessionId);
+        }
+        return sessionId;
     }
 
     private getHeaders() {
@@ -380,8 +380,10 @@ export class UnleashClient extends TinyEmitter {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'If-None-Match': this.etag,
         };
+        if (this.etag) {
+            headers['If-None-Match'] = this.etag;
+        }
         Object.entries(this.customHeaders)
             .filter(notNullOrUndefined)
             .forEach(([name, value]) => (headers[name] = value));

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ export class UnleashClient extends TinyEmitter {
         return { ...variant, feature_enabled: enabled };
     }
 
-    public async updateToggles() {
+    private async updateToggles() {
         if (this.timerRef || this.readyEventEmitted) {
             await this.fetchToggles();
         } else if (this.started) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -400,11 +400,14 @@ export class UnleashClient extends TinyEmitter {
     }
 
     private getHeaders() {
+        const isPOST = this.usePOSTrequests;
         const headers = {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
-            'Content-Type': 'application/json',
         };
+        if (isPOST) {
+            headers['Content-Type'] = 'application/json';
+        }
         if (this.etag) {
             headers['If-None-Match'] = this.etag;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import LocalStorageProvider from './storage-provider-local';
 import EventsHandler from './events-handler';
 import { notNullOrUndefined, urlWithContextAsQuery } from './util';
 
-const DEFINED_FIELDS = ['userId', 'sessionId', 'remoteAddress'];
+const DEFINED_FIELDS = ['userId', 'sessionId', 'remoteAddress', 'currentTime'];
 
 interface IStaticContext {
     appName: string;
@@ -17,6 +17,7 @@ interface IMutableContext {
     userId?: string;
     sessionId?: string;
     remoteAddress?: string;
+    currentTime?: string;
     properties?: {
         [key: string]: string;
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,10 @@ export class UnleashClient extends TinyEmitter {
         }
         const timestamp = Date.now();
 
-        return !!(this.lastRefreshTimestamp && timestamp - this.lastRefreshTimestamp <= this.togglesStorageTTL);
+        return !!(
+            this.lastRefreshTimestamp &&
+            timestamp - this.lastRefreshTimestamp <= this.togglesStorageTTL
+        );
     }
 
     private async updateLastRefresh() {
@@ -508,7 +511,7 @@ export class UnleashClient extends TinyEmitter {
                 }
 
                 this.updateLastRefresh();
-        } catch (e) {
+            } catch (e) {
                 console.error('Unleash: unable to fetch feature toggles', e);
                 this.sdkState = 'error';
                 this.emit(EVENTS.ERROR, e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ interface IConfig extends IStaticContext {
     customHeaders?: Record<string, string>;
     impressionDataAll?: boolean;
     usePOSTrequests?: boolean;
-    toggleStorageTTL?: number;
+    togglesStorageTTL?: number;
 }
 
 interface IVariant {
@@ -147,7 +147,7 @@ export class UnleashClient extends TinyEmitter {
     private usePOSTrequests = false;
     private started = false;
     private sdkState: SdkState;
-    private toggleStorageTTL: number;
+    private togglesStorageTTL: number;
     private lastRefreshTimestamp: number;
 
     constructor({
@@ -169,7 +169,7 @@ export class UnleashClient extends TinyEmitter {
         customHeaders = {},
         impressionDataAll = false,
         usePOSTrequests = false,
-        toggleStorageTTL = 0,
+        togglesStorageTTL = 0,
     }: IConfig) {
         super();
         // Validations
@@ -198,7 +198,7 @@ export class UnleashClient extends TinyEmitter {
         this.context = { appName, environment, ...context };
         this.usePOSTrequests = usePOSTrequests;
         this.sdkState = 'initializing';
-        this.toggleStorageTTL = toggleStorageTTL * 1000;
+        this.togglesStorageTTL = togglesStorageTTL * 1000;
         this.lastRefreshTimestamp = 0;
 
         this.ready = new Promise((resolve) => {
@@ -433,12 +433,12 @@ export class UnleashClient extends TinyEmitter {
     }
 
     private isUpToDate() {
-        if (this.toggleStorageTTL <= 0 || this.toggles.length === 0) {
+        if (this.togglesStorageTTL <= 0 || this.toggles.length === 0) {
             return false;
         }
         const timestamp = Date.now();
 
-        return !!(this.lastRefreshTimestamp && timestamp - this.lastRefreshTimestamp <= this.toggleStorageTTL);
+        return !!(this.lastRefreshTimestamp && timestamp - this.lastRefreshTimestamp <= this.togglesStorageTTL);
     }
 
     private async updateLastRefresh() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ export class UnleashClient extends TinyEmitter {
         this.context = { appName, environment, ...context };
         this.usePOSTrequests = usePOSTrequests;
         this.sdkState = 'initializing';
-        this.toggleStorageTTL = toggleStorageTTL;
+        this.toggleStorageTTL = toggleStorageTTL * 1000;
         this.lastRefreshTimestamp = 0;
 
         this.ready = new Promise((resolve) => {
@@ -437,9 +437,8 @@ export class UnleashClient extends TinyEmitter {
             return false;
         }
         const timestamp = Date.now();
-        const unleashRefreshIntervalMs = this.toggleStorageTTL * 60 * 1000;
 
-        return !!(this.lastRefreshTimestamp && timestamp - this.lastRefreshTimestamp <= unleashRefreshIntervalMs);
+        return !!(this.lastRefreshTimestamp && timestamp - this.lastRefreshTimestamp <= this.toggleStorageTTL);
     }
 
     private async updateLastRefresh() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ const defaultVariant: IVariant = {
     feature_enabled: false,
 };
 const storeKey = 'repo';
-const lastUpdateKey = 'lastUpdate';
+const lastUpdateKey = 'repoLastUpdateTimestamp';
 
 type SdkState = 'initializing' | 'healthy' | 'error';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,10 +449,7 @@ export class UnleashClient extends TinyEmitter {
     private async fetchToggles() {
         if (this.fetch) {
             if (this.isUpToDate()) {
-                if (!this.bootstrap && !this.readyEventEmitted) {
-                    this.emit(EVENTS.READY);
-                    this.readyEventEmitted = true;
-                }
+                this.emitReady();
                 return;
             }
             if (this.abortController) {
@@ -507,10 +504,7 @@ export class UnleashClient extends TinyEmitter {
                         this.sdkState = 'healthy';
                     }
 
-                    if (!this.bootstrap && !this.readyEventEmitted) {
-                        this.emit(EVENTS.READY);
-                        this.readyEventEmitted = true;
-                    }
+                    this.emitReady();
                 }
 
                 this.updateLastRefresh();
@@ -521,6 +515,13 @@ export class UnleashClient extends TinyEmitter {
             } finally {
                 this.abortController = null;
             }
+        }
+    }
+
+    private emitReady() {
+        if (!this.bootstrap && !this.readyEventEmitted) {
+            this.emit(EVENTS.READY);
+            this.readyEventEmitted = true;
         }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -503,8 +503,7 @@ export class UnleashClient extends TinyEmitter {
                         type: 'HttpError',
                         code: response.status,
                     });
-                }
-                else if (response.status !== 304) {
+                } else if (response.status !== 304) {
                     this.etag = response.headers.get('ETag') || '';
                     const data = await response.json();
                     await this.storeToggles(data.toggles);

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,14 @@
   dependencies:
     "@babel/highlight" "^7.22.5"
 
+"@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.4.tgz#03ae5af150be94392cb5c7ccd97db5a19a5da6aa"
+  integrity sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==
+  dependencies:
+    "@babel/highlight" "^7.23.4"
+    chalk "^2.4.2"
+
 "@babel/compat-data@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.5.tgz#b1f6c86a02d85d2dd3368a2b67c09add8cd0c255"
@@ -58,6 +66,16 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.4.tgz#4a41377d8566ec18f807f42962a7f3551de83d1c"
+  integrity sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==
+  dependencies:
+    "@babel/types" "^7.23.4"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
 "@babel/helper-compilation-targets@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz#fc7319fc54c5e2fa14b2909cf3c5fd3046813e02"
@@ -69,18 +87,23 @@
     lru-cache "^5.1.1"
     semver "^6.3.0"
 
+"@babel/helper-environment-visitor@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz#96159db61d34a29dba454c959f5ae4a649ba9167"
+  integrity sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==
+
 "@babel/helper-environment-visitor@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz#f06dd41b7c1f44e1f8da6c4055b41ab3a09a7e98"
   integrity sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==
 
-"@babel/helper-function-name@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz#ede300828905bb15e582c037162f99d5183af1be"
-  integrity sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==
+"@babel/helper-function-name@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz#1f9a3cdbd5b2698a670c30d2735f9af95ed52759"
+  integrity sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==
   dependencies:
-    "@babel/template" "^7.22.5"
-    "@babel/types" "^7.22.5"
+    "@babel/template" "^7.22.15"
+    "@babel/types" "^7.23.0"
 
 "@babel/helper-hoist-variables@^7.22.5":
   version "7.22.5"
@@ -129,10 +152,27 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-split-export-declaration@^7.22.6":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz#322c61b7310c0997fe4c323955667f18fcefb91c"
+  integrity sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-string-parser@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
+"@babel/helper-string-parser@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
+  integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
+
+"@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
 "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
@@ -162,10 +202,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
   integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
+
+"@babel/parser@^7.22.15", "@babel/parser@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.4.tgz#409fbe690c333bb70187e2de4021e1e47a026661"
+  integrity sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -272,6 +326,15 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/template@^7.22.15":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
+  integrity sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==
+  dependencies:
+    "@babel/code-frame" "^7.22.13"
+    "@babel/parser" "^7.22.15"
+    "@babel/types" "^7.22.15"
+
 "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
@@ -282,18 +345,18 @@
     "@babel/types" "^7.22.5"
 
 "@babel/traverse@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.5.tgz#44bd276690db6f4940fdb84e1cb4abd2f729ccd1"
-  integrity sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.4.tgz#c2790f7edf106d059a0098770fe70801417f3f85"
+  integrity sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==
   dependencies:
-    "@babel/code-frame" "^7.22.5"
-    "@babel/generator" "^7.22.5"
-    "@babel/helper-environment-visitor" "^7.22.5"
-    "@babel/helper-function-name" "^7.22.5"
+    "@babel/code-frame" "^7.23.4"
+    "@babel/generator" "^7.23.4"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
     "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.5"
-    "@babel/parser" "^7.22.5"
-    "@babel/types" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.23.4"
+    "@babel/types" "^7.23.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -304,6 +367,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.22.5"
     "@babel/helper-validator-identifier" "^7.22.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.22.15", "@babel/types@^7.23.0", "@babel/types@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.4.tgz#7206a1810fc512a7f7f7d4dace4cb4c1c9dbfb8e"
+  integrity sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1219,7 +1291,7 @@ caniuse-lite@^1.0.30001502:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz#88b6ff1b2cf735f1f3361dc1a15b59f0561aa398"
   integrity sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

This pull request is a proposal for fixing this [issue](https://github.com/Unleash/unleash-proxy-client-js/issues/201) to add compatibility with service worker and browser extensions to avoid multiple requests to the proxy server each time the service worker is started.

It introduces a new option `togglesStorageTTL` that prevents fetching the flags if they are up to date (not older than the number of seconds defined in this option).

A second pull request will come to fix the "refresh" problem described in the issue.

<!-- Does it close an issue? Multiple? -->
Closes #201

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
Main changes concerned `index.ts` file.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
