### PR TITLE
fix: don't enter error state when request is aborted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -484,9 +484,14 @@ export class UnleashClient extends TinyEmitter {
                     });
                 }
             } catch (e) {
-                console.error('Unleash: unable to fetch feature toggles', e);
-                this.sdkState = 'error';
-                this.emit(EVENTS.ERROR, e);
+                if (!(e instanceof DOMException && e.name === 'AbortError')) {
+                    console.error(
+                        'Unleash: unable to fetch feature toggles',
+                        e
+                    );
+                    this.sdkState = 'error';
+                    this.emit(EVENTS.ERROR, e);
+                }
             } finally {
                 this.abortController = null;
             }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Prevents the SDK entering the error state when a request is aborted. An aborted request doesn't indicate that there's an error, only that a new request has superseded the previous one.

An example of the current behavior:

1. Application starts up <- starts in `initializing` state
3. Request for `flags A`
5. Context updated with `userId`
6. Request for `flags B`
7. Request for `flags A` cancelled <- transitions to `error` state
8. Request for `flags B` completed <- transitions to `healthy` state

Expected behavior:

1. Application starts up <- starts in `initializing` state
3. Request for `flags A`
5. Context updated with `userId`
6. Request for `flags B`
7. Request for `flags A` cancelled <- remains in `initializing` state
8. Request for `flags B` completed <- transitions to `healthy` state


I noticed this because in our case Sentry captures `console.error` messages, and we are seeing a lot of Sentry issues due to the `console.error` in the catch handler.