### PR TITLE
feat: allow for AbortController to be optional

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -642,6 +642,27 @@ test('Should not trigger error on abort', async () => {
     await client.updateContext({ userId: '789' });
 });
 
+test('Should run without abort controller', async () => {
+    fetchMock.mockResponse(JSON.stringify(data));
+    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        createAbortController: () => null,
+    };
+    const client = new UnleashClient(config);
+
+    await client.start();
+    client.updateContext({ userId: '123' });
+    client.updateContext({ userId: '456' });
+    await client.updateContext({ userId: '789' });
+
+    expect(abortSpy).toBeCalledTimes(0);
+    abortSpy.mockRestore();
+});
+
 test.each([400, 401, 403, 404, 429, 500, 502, 503])(
     'Should publish error when fetch receives a %d error',
     async (errorCode) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ interface IConfig extends IStaticContext {
     storageProvider?: IStorageProvider;
     context?: IMutableContext;
     fetch?: any;
-    createAbortController?: () => AbortController;
+    createAbortController?: () => AbortController | null;
     bootstrap?: IToggle[];
     bootstrapOverride?: boolean;
     headerName?: string;
@@ -100,7 +100,9 @@ export const resolveFetch = () => {
     try {
         if (typeof window !== 'undefined' && 'fetch' in window) {
             return fetch.bind(window);
-        } else if ('fetch' in globalThis) {
+        }
+
+        if ('fetch' in globalThis) {
             return fetch.bind(globalThis);
         }
     } catch (e) {
@@ -114,7 +116,9 @@ const resolveAbortController = () => {
     try {
         if (typeof window !== 'undefined' && 'AbortController' in window) {
             return () => new window.AbortController();
-        } else if ('fetch' in globalThis) {
+        }
+
+        if ('fetch' in globalThis) {
             return () => new globalThis.AbortController();
         }
     } catch (e) {
@@ -135,7 +139,7 @@ export class UnleashClient extends TinyEmitter {
     private metrics: Metrics;
     private ready: Promise<void>;
     private fetch: any;
-    private createAbortController?: () => AbortController;
+    private createAbortController?: () => AbortController | null;
     private abortController?: AbortController | null;
     private bootstrap?: IToggle[];
     private bootstrapOverride: boolean;
@@ -431,8 +435,7 @@ export class UnleashClient extends TinyEmitter {
             if (this.abortController) {
                 this.abortController.abort();
             }
-            this.abortController =
-                this.createAbortController && this.createAbortController();
+            this.abortController = this.createAbortController?.();
             const signal = this.abortController
                 ? this.abortController.signal
                 : undefined;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
In an environment where AbortController is not available, there should be a way to use this SDK without errors.

Related to https://github.com/Unleash/unleash-client-nextjs/issues/76

Internally: [1-2470](https://linear.app/unleash/issue/1-2470/nextjs-sdk-76-warnings-in-serverless)
