### PR TITLE
Fix: emit READY event once when bootstrapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,7 @@ export class UnleashClient extends TinyEmitter {
             await this.storage.save(storeKey, this.bootstrap);
             this.toggles = this.bootstrap;
             this.emit(EVENTS.READY);
+            this.readyEventEmitted = true;
         }
 
         this.sdkState = 'healthy';


### PR DESCRIPTION
## About the changes
_READY_ event was emitted twice if bootstrapping (and overriding cache: `bootstrapOverride` `true`, that is the default)