### PR TITLE
fix: ready state when bootstrapping

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1756,3 +1756,28 @@ describe('READY event emission', () => {
         expect(client.emit).toHaveBeenCalledWith(EVENTS.READY);
     });
 });
+
+test('should be in ready state if bootstrapping', (done) => {
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        bootstrap: [
+            {
+                enabled: false,
+                name: 'test-frontend',
+                variant: { name: 'some-variant', enabled: false },
+                impressionData: false,
+            },
+        ],
+        fetch: async () => {},
+    };
+
+    const client = new UnleashClient(config);
+
+    client.on(EVENTS.READY, () => {
+        expect(client.isReady()).toBe(true);
+        client.stop();
+        done();
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,7 @@ export class UnleashClient extends TinyEmitter {
         ) {
             await this.storage.save(storeKey, this.bootstrap);
             this.toggles = this.bootstrap;
+            this.sdkState = 'healthy';
             this.emit(EVENTS.READY);
         }
 
@@ -396,7 +397,7 @@ export class UnleashClient extends TinyEmitter {
     }
 
     public isReady(): boolean {
-        return this.readyEventEmitted;
+        return this.sdkState === 'healthy' || this.readyEventEmitted;
     }
 
     public getError(): SdkState {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ export class UnleashClient extends TinyEmitter {
     private eventsHandler: EventsHandler;
     private customHeaders: Record<string, string>;
     private readyEventEmitted = false;
+    private fetchedFromServer = false;
     private usePOSTrequests = false;
     private started = false;
     private sdkState: SdkState;
@@ -291,7 +292,7 @@ export class UnleashClient extends TinyEmitter {
     }
 
     private async updateToggles() {
-        if (this.timerRef || this.readyEventEmitted) {
+        if (this.timerRef || this.fetchedFromServer) {
             await this.fetchToggles();
         } else if (this.started) {
             await new Promise<void>((resolve) => {
@@ -362,6 +363,7 @@ export class UnleashClient extends TinyEmitter {
             await this.storage.save(storeKey, this.bootstrap);
             this.toggles = this.bootstrap;
             this.sdkState = 'healthy';
+            this.readyEventEmitted = true;
             this.emit(EVENTS.READY);
         }
 
@@ -397,7 +399,7 @@ export class UnleashClient extends TinyEmitter {
     }
 
     public isReady(): boolean {
-        return this.sdkState === 'healthy' || this.readyEventEmitted;
+        return this.readyEventEmitted;
     }
 
     public getError(): SdkState {
@@ -483,9 +485,10 @@ export class UnleashClient extends TinyEmitter {
                         this.sdkState = 'healthy';
                     }
 
-                    if (!this.readyEventEmitted) {
-                        this.emit(EVENTS.READY);
+                    if (!this.fetchedFromServer) {
+                        this.fetchedFromServer = true;
                         this.readyEventEmitted = true;
+                        this.emit(EVENTS.READY);
                     }
                 } else if (!response.ok && response.status !== 304) {
                     console.error(


### PR DESCRIPTION
## About the changes
When bootstrapping there is an edge case when:

- state of the `this.ready` promise cannot be resolved synchronously
- `readyEventEmitted` is not set until toggles are received from the server

and that made `isReady()` hard to implement.

Previously, the SDK wouldn’t be “ready” if it only bootstrapped, but the attempt to fetch flags failed. Now, we set the SDK to ready both when it’s bootstrapped and when you successfully fetch flags; whichever comes first. Otherwise, the existing functionality hasn’t changed. Essentially, what you’re doing here is adding a separate variable to track flag fetch status, making readyEventEmitted more accurately do what it says