### PR TITLE
fix: error method return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -402,7 +402,7 @@ export class UnleashClient extends TinyEmitter {
         return this.readyEventEmitted;
     }
 
-    public getError(): SdkState {
+    public getError() {
         return this.sdkState === 'error' ? this.lastError : undefined;
     }
 


### PR DESCRIPTION
Fixing incompatible type for the use case not caught by TS because of "any" type on lastError