### PR TITLE
feat: make updateToggles and sendMetrics available as public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,7 @@ const unleash = new UnleashClient({
 **NOTES: ⚠️**
 If `bootstrapOverride` is `true` (by default), any local cached data will be overridden with the bootstrap specified.   
 If `bootstrapOverride` is `false` any local cached data will not be overridden unless the local cache is empty.
+
+## Manage your own refresh mechanism
+
+If you do not want to use the internal refresh mechanism provided by the `refreshInterval` or `metricsInterval` options, you can handle it yourself using the public `updateToggles` and `sendMetrics` methods.

--- a/README.md
+++ b/README.md
@@ -296,4 +296,6 @@ If `bootstrapOverride` is `false` any local cached data will not be overridden u
 
 ## Manage your own refresh mechanism
 
-If you do not want to use the internal refresh mechanism provided by the `refreshInterval` or `metricsInterval` options, you can handle it yourself using the public `updateToggles` and `sendMetrics` methods.
+You can opt out of the Unleash feature flag auto-refresh mechanism and metrics update by settings the `refreshInterval` and/or `metricsInterval` options to `false`. 
+In this case, it becomes your responsibility to call `updateToggles` and/or `sendMetrics` methods.
+This approach is useful in environments that do not support the `setInterval` API, such as service workers.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,7 @@ import {
     lastUpdateKey,
 } from './index';
 import { getTypeSafeRequest, getTypeSafeRequestUrl } from './test';
+import Metrics from './metrics';
 
 jest.useFakeTimers();
 
@@ -1655,6 +1656,26 @@ test('Should report metrics', async () => {
         },
     });
     client.stop();
+});
+
+test('should send metrics when sendMetrics called', async () => {
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+    };
+
+    jest.spyOn(Metrics.prototype, 'sendMetrics');
+
+    const client = new UnleashClient(config);
+
+    client.start();
+
+    expect(Metrics.prototype.sendMetrics).not.toHaveBeenCalled();
+
+    await client.sendMetrics();
+
+    expect(Metrics.prototype.sendMetrics).toHaveBeenCalled();
 });
 
 test('Should emit RECOVERED event when sdkStatus is error and status is less than 400', (done) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2320,7 +2320,7 @@ describe('updateToggles', () => {
         expect(fetchMock).toHaveBeenCalled();
     });
 
-    it('should wait for readyness before update toggles', async () => {
+    it('should wait for client readiness before the toggles update', async () => {
         const config: IConfig = {
             url: 'http://localhost/test',
             clientKey: '12',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2289,3 +2289,54 @@ describe('Experimental options togglesStorageTTL enabled', () => {
         });
     });
 });
+
+describe('updateToggles', () => {
+    it('should not update toggles when not started', () => {
+        const config: IConfig = {
+            url: 'http://localhost/test',
+            clientKey: '12',
+            appName: 'web',
+        };
+        const client = new UnleashClient(config);
+
+        client.updateToggles();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should update toggles when started', async () => {
+        const config: IConfig = {
+            url: 'http://localhost/test',
+            clientKey: '12',
+            appName: 'web',
+        };
+        const client = new UnleashClient(config);
+
+        await client.start();
+        fetchMock.mockClear();
+
+        client.updateToggles();
+
+        expect(fetchMock).toHaveBeenCalled();
+    });
+
+    it('should wait for readyness before update toggles', async () => {
+        const config: IConfig = {
+            url: 'http://localhost/test',
+            clientKey: '12',
+            appName: 'web',
+            refreshInterval: 0,
+        };
+        const client = new UnleashClient(config);
+
+        client.start();
+
+        client.updateToggles();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        client.emit(EVENTS.READY);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ export class UnleashClient extends TinyEmitter {
         return { ...variant, feature_enabled: enabled };
     }
 
-    private async updateToggles() {
+    public async updateToggles() {
         if (this.timerRef || this.fetchedFromServer) {
             await this.fetchToggles();
         } else if (this.started) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,6 +446,10 @@ export class UnleashClient extends TinyEmitter {
         return this.sdkState === 'error' ? this.lastError : undefined;
     }
 
+    public sendMetrics() {
+        return this.metrics.sendMetrics();
+    }
+
     private async resolveSessionId(): Promise<string> {
         if (this.context.sessionId) {
             return this.context.sessionId;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

In order to manage contexts where the internal refresh mechanism does not correspond to technical needs or constraints (Service Workers for example), we propose to make the `updateToggles` and `sendMetrics` methods available as public as discussed in this [conversation](https://github.com/Unleash/unleash-proxy-client-js/issues/201#issuecomment-2273099747).

<!-- Does it close an issue? Multiple? -->
Closes second part of #201

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->
