### PR TITLE
feat(1 3223): add client identification headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-proxy-client",
   "version": "3.6.1",
-  "description": "A browser client that can be used together with the unleash-proxy.",
+  "description": "A browser client that can be used together with Unleash Edge or the Unleash Frontend API.",
   "type": "module",
   "main": "./build/index.cjs",
   "types": "./build/cjs/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { FetchMock } from 'jest-fetch-mock';
+import { version as sdkVersion } from '../package.json';
 import 'jest-localstorage-mock';
 import * as data from './test/testdata.json';
 import IStorageProvider from './storage-provider';
@@ -1372,7 +1373,7 @@ test('Should add X-UNLEASH headers', async () => {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     expect(request.headers).toMatchObject({
-        'x-unleash-sdk': 'unleash-js@1.0.0',
+        'x-unleash-sdk': `unleash-js@${sdkVersion}`,
         'x-unleash-connection-id': expect.stringMatching(uuidFormat),
         'x-unleash-appname': 'web',
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1356,6 +1356,28 @@ test('Should pass custom headers', async () => {
     });
 });
 
+test('Should add X-UNLEASH headers', async () => {
+    fetchMock.mockResponses([JSON.stringify(data), { status: 200 }]);
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: 'some123key',
+        appName: 'web',
+    };
+    const client = new UnleashClient(config);
+    await client.start();
+
+    const request = getTypeSafeRequest(fetchMock);
+
+    const uuidFormat =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+    expect(request.headers).toMatchObject({
+        'x-unleash-sdk': 'unleash-js@1.0.0',
+        'x-unleash-connection-id': expect.stringMatching(uuidFormat),
+        'x-unleash-appname': 'web',
+    });
+});
+
 test('Should emit impression events on getVariant calls when impressionData is true', (done) => {
     const bootstrap = [
         {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1357,7 +1357,7 @@ test('Should pass custom headers', async () => {
     });
 });
 
-test('Should add X-UNLEASH headers', async () => {
+test('Should add `x-unleash` headers', async () => {
     fetchMock.mockResponses(
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { FetchMock } from 'jest-fetch-mock';
-import { version as sdkVersion } from '../package.json';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJSON = require('../package.json');
 import 'jest-localstorage-mock';
 import * as data from './test/testdata.json';
 import IStorageProvider from './storage-provider';
@@ -1382,7 +1383,7 @@ test('Should add `x-unleash` headers', async () => {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     const expectedHeaders = {
-        'x-unleash-sdk': `unleash-js@${sdkVersion}`,
+        'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
         'x-unleash-connection-id': expect.stringMatching(uuidFormat),
         'x-unleash-appname': appName,
     };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1389,7 +1389,7 @@ test('Should add `x-unleash` headers', async () => {
     };
 
     const getConnectionId = (request: any) =>
-        JSON.parse(JSON.stringify(request.headers))['x-unleash-connection-id'];
+        request.headers['x-unleash-connection-id'];
 
     expect(featureRequest.headers).toMatchObject(expectedHeaders);
     expect(metricsRequest.headers).toMatchObject(expectedHeaders);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
     urlWithContextAsQuery,
 } from './util';
 
-import packageJSON = require('../package.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJSON = require('../package.json');
 
 const DEFINED_FIELDS = [
     'userId',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { TinyEmitter } from 'tiny-emitter';
+import { v4 as uuidv4 } from 'uuid';
 import Metrics from './metrics';
 import type IStorageProvider from './storage-provider';
 import InMemoryStorageProvider from './storage-provider-inmemory';
@@ -169,6 +170,8 @@ export class UnleashClient extends TinyEmitter {
     private lastError: any;
     private experimental: IExperimentalConfig;
     private lastRefreshTimestamp: number;
+    private connectionId: string;
+    private sdkVersion: string;
 
     constructor({
         storageProvider,
@@ -274,6 +277,9 @@ export class UnleashClient extends TinyEmitter {
             customHeaders,
             metricsIntervalInitial,
         });
+
+        this.connectionId = uuidv4();
+        this.sdkVersion = '1.0.0';
     }
 
     public getAllToggles(): IToggle[] {
@@ -468,6 +474,9 @@ export class UnleashClient extends TinyEmitter {
         const headers = {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
+            'x-unleash-sdk': `unleash-js@${this.sdkVersion}`,
+            'x-unleash-connection-id': this.connectionId,
+            'x-unleash-appname': this.context.appName,
         };
         if (isPOST) {
             headers['Content-Type'] = 'application/json';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { TinyEmitter } from 'tiny-emitter';
-import { version as sdkVersion } from '../package.json';
 import { v4 as uuidv4 } from 'uuid';
 import Metrics from './metrics';
 import type IStorageProvider from './storage-provider';
@@ -11,6 +10,8 @@ import {
     notNullOrUndefined,
     urlWithContextAsQuery,
 } from './util';
+
+import packageJSON = require('../package.json');
 
 const DEFINED_FIELDS = [
     'userId',
@@ -172,7 +173,6 @@ export class UnleashClient extends TinyEmitter {
     private experimental: IExperimentalConfig;
     private lastRefreshTimestamp: number;
     private connectionId: string;
-    private sdkVersion: string;
 
     constructor({
         storageProvider,
@@ -266,7 +266,6 @@ export class UnleashClient extends TinyEmitter {
         this.bootstrapOverride = bootstrapOverride;
 
         this.connectionId = uuidv4();
-        this.sdkVersion = sdkVersion;
 
         this.metrics = new Metrics({
             onError: this.emit.bind(this, EVENTS.ERROR),
@@ -281,7 +280,6 @@ export class UnleashClient extends TinyEmitter {
             customHeaders,
             metricsIntervalInitial,
             connectionId: this.connectionId,
-            sdkVersion,
         });
     }
 
@@ -477,7 +475,7 @@ export class UnleashClient extends TinyEmitter {
         const headers = {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
-            'x-unleash-sdk': `unleash-js@${this.sdkVersion}`,
+            'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.context.appName,
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { TinyEmitter } from 'tiny-emitter';
+import { version as sdkVersion } from '../package.json';
 import { v4 as uuidv4 } from 'uuid';
 import Metrics from './metrics';
 import type IStorageProvider from './storage-provider';
@@ -279,7 +280,7 @@ export class UnleashClient extends TinyEmitter {
         });
 
         this.connectionId = uuidv4();
-        this.sdkVersion = '1.0.0';
+        this.sdkVersion = sdkVersion;
     }
 
     public getAllToggles(): IToggle[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,9 @@ export class UnleashClient extends TinyEmitter {
             bootstrap && bootstrap.length > 0 ? bootstrap : undefined;
         this.bootstrapOverride = bootstrapOverride;
 
+        this.connectionId = uuidv4();
+        this.sdkVersion = sdkVersion;
+
         this.metrics = new Metrics({
             onError: this.emit.bind(this, EVENTS.ERROR),
             onSent: this.emit.bind(this, EVENTS.SENT),
@@ -277,10 +280,9 @@ export class UnleashClient extends TinyEmitter {
             headerName,
             customHeaders,
             metricsIntervalInitial,
+            connectionId: this.connectionId,
+            sdkVersion,
         });
-
-        this.connectionId = uuidv4();
-        this.sdkVersion = sdkVersion;
     }
 
     public getAllToggles(): IToggle[] {

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -22,6 +22,7 @@ test('should be disabled by flag disableMetrics', async () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 0,
+        connectionId: '123',
     });
 
     metrics.count('foo', true);
@@ -42,6 +43,7 @@ test('should send metrics', async () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 0,
+        connectionId: '123',
     });
 
     metrics.count('foo', true);
@@ -79,6 +81,7 @@ test('should send metrics with custom auth header', async () => {
         fetch: fetchMock,
         headerName: 'NotAuthorization',
         metricsIntervalInitial: 0,
+        connectionId: '123',
     });
 
     metrics.count('foo', true);
@@ -103,6 +106,7 @@ test('Should send initial metrics after 2 seconds', () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 2,
+        connectionId: '123',
     });
 
     metrics.start();
@@ -127,6 +131,7 @@ test('Should send initial metrics after 20 seconds, when metricsIntervalInitial 
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 20,
+        connectionId: '123',
     });
 
     metrics.start();
@@ -151,6 +156,7 @@ test('Should send metrics for initial and after metrics interval', () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 2,
+        connectionId: '123',
     });
 
     metrics.start();
@@ -178,6 +184,7 @@ test('Should not send initial metrics if disabled', () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 0,
+        connectionId: '123',
     });
 
     metrics.start();
@@ -202,6 +209,7 @@ test('should send metrics based on timer interval', async () => {
         fetch: fetchMock,
         headerName: 'Authorization',
         metricsIntervalInitial: 2,
+        connectionId: '123',
     });
 
     metrics.start();
@@ -242,6 +250,7 @@ describe('Custom headers for metrics', () => {
             fetch: fetchMock,
             headerName: 'Authorization',
             customHeaders,
+            connectionId: '123',
             metricsIntervalInitial: 2,
         });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,7 @@
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/main/src/metrics.ts
 
 import { notNullOrUndefined } from './util';
+import packageJSON = require('../package.json');
 
 export interface MetricsOptions {
     onError: OnError;
@@ -15,7 +16,6 @@ export interface MetricsOptions {
     customHeaders?: Record<string, string>;
     metricsIntervalInitial: number;
     connectionId: string;
-    sdkVersion: string;
 }
 
 interface VariantBucket {
@@ -56,7 +56,6 @@ export default class Metrics {
     private customHeaders: Record<string, string>;
     private metricsIntervalInitial: number;
     private connectionId: string;
-    private sdkVersion: string;
 
     constructor({
         onError,
@@ -71,7 +70,6 @@ export default class Metrics {
         customHeaders = {},
         metricsIntervalInitial,
         connectionId,
-        sdkVersion,
     }: MetricsOptions) {
         this.onError = onError;
         this.onSent = onSent || doNothing;
@@ -86,7 +84,6 @@ export default class Metrics {
         this.headerName = headerName;
         this.customHeaders = customHeaders;
         this.connectionId = connectionId;
-        this.sdkVersion = sdkVersion;
     }
 
     public start() {
@@ -129,7 +126,7 @@ export default class Metrics {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'x-unleash-sdk': `unleash-js@${this.sdkVersion}`,
+            'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.appName,
         };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,7 +1,8 @@
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/main/src/metrics.ts
 
 import { notNullOrUndefined } from './util';
-import packageJSON = require('../package.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJSON = require('../package.json');
 
 export interface MetricsOptions {
     onError: OnError;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -14,6 +14,8 @@ export interface MetricsOptions {
     headerName: string;
     customHeaders?: Record<string, string>;
     metricsIntervalInitial: number;
+    connectionId: string;
+    sdkVersion: string;
 }
 
 interface VariantBucket {
@@ -53,6 +55,8 @@ export default class Metrics {
     private headerName: string;
     private customHeaders: Record<string, string>;
     private metricsIntervalInitial: number;
+    private connectionId: string;
+    private sdkVersion: string;
 
     constructor({
         onError,
@@ -66,6 +70,8 @@ export default class Metrics {
         headerName,
         customHeaders = {},
         metricsIntervalInitial,
+        connectionId,
+        sdkVersion,
     }: MetricsOptions) {
         this.onError = onError;
         this.onSent = onSent || doNothing;
@@ -79,6 +85,8 @@ export default class Metrics {
         this.fetch = fetch;
         this.headerName = headerName;
         this.customHeaders = customHeaders;
+        this.connectionId = connectionId;
+        this.sdkVersion = sdkVersion;
     }
 
     public start() {
@@ -121,6 +129,9 @@ export default class Metrics {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
+            'x-unleash-sdk': `unleash-js@${this.sdkVersion}`,
+            'x-unleash-connection-id': this.connectionId,
+            'x-unleash-appname': this.appName,
         };
 
         Object.entries(this.customHeaders)


### PR DESCRIPTION


This PR adds client identification headers to the feature and metrics calls that the client makes to Unleash. The headers are:
- `x-unleash-appname`: the name of the application that is using the client
- `x-unleash-connection-id`: a unique identifier for the current instance of the client
- `x-unleash-sdk`: sdk information in the format `unleash-js@<version>`

## Discussion points:

What should we call the client here? Is `unleash-js` correct? Should it be `unleash-browser`? `unleash-proxy-client`?

Second: should the client be possible to override? This package is also what powers our React, Svelte, and Vue SDKs. Should they be able to override it (so you'd get `unleash-react@<version>`)? I think that would be useful
