### PR TITLE
fix: embed version at compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vscode/
 coverage/
 .idea
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/runtime": "^7.23.1",
     "@rollup/plugin-commonjs": "^25.0.5",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/jest": "^29.5.5",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,6 +3,10 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
 import nodePolyfills from 'rollup-plugin-node-polyfills';
+import replace from '@rollup/plugin-replace';
+import fs from 'fs';
+
+const version = JSON.parse(fs.readFileSync('./package.json', 'UTF-8')).version;
 
 export default {
     input: './src/index.ts',
@@ -25,6 +29,10 @@ export default {
         }
     ],
     plugins: [
+        replace({
+            '__VERSION__': version,
+            preventAssignment: true
+        }),
         typescript({
             compilerOptions: {
                 lib: ['es5', 'es6', 'dom'],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1381,7 +1381,8 @@ test('Should add `x-unleash` headers', async () => {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     const expectedHeaders = {
-        'x-unleash-sdk': `unleash-js@__VERSION__`,
+        // will be replaced at build time with the actual version
+        'x-unleash-sdk': 'unleash-js@__VERSION__',
         'x-unleash-connection-id': expect.stringMatching(uuidFormat),
         'x-unleash-appname': appName,
     };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,4 @@
 import { FetchMock } from 'jest-fetch-mock';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const packageJSON = require('../package.json');
 import 'jest-localstorage-mock';
 import * as data from './test/testdata.json';
 import IStorageProvider from './storage-provider';
@@ -1383,7 +1381,7 @@ test('Should add `x-unleash` headers', async () => {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     const expectedHeaders = {
-        'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
+        'x-unleash-sdk': `unleash-js@__VERSION__`,
         'x-unleash-connection-id': expect.stringMatching(uuidFormat),
         'x-unleash-appname': appName,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
     notNullOrUndefined,
     urlWithContextAsQuery,
 } from './util';
-import {sdkVersion} from "./version";
+import { sdkVersion } from './version';
 
 const DEFINED_FIELDS = [
     'userId',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
     notNullOrUndefined,
     urlWithContextAsQuery,
 } from './util';
+import {sdkVersion} from "./version";
 
 const DEFINED_FIELDS = [
     'userId',
@@ -473,7 +474,7 @@ export class UnleashClient extends TinyEmitter {
         const headers = {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
-            'x-unleash-sdk': `unleash-js@$__VERSION__`,
+            'x-unleash-sdk': sdkVersion,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.context.appName,
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,6 @@ import {
     urlWithContextAsQuery,
 } from './util';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const packageJSON = require('../package.json');
-
 const DEFINED_FIELDS = [
     'userId',
     'sessionId',
@@ -476,7 +473,7 @@ export class UnleashClient extends TinyEmitter {
         const headers = {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
-            'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
+            'x-unleash-sdk': `unleash-js@$__VERSION__`,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.context.appName,
         };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,7 @@
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/main/src/metrics.ts
 
 import { notNullOrUndefined } from './util';
+import {sdkVersion} from "./version";
 
 export interface MetricsOptions {
     onError: OnError;
@@ -125,7 +126,7 @@ export default class Metrics {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'x-unleash-sdk': `unleash-js@$__VERSION__`,
+            'x-unleash-sdk': sdkVersion,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.appName,
         };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,8 +1,6 @@
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/main/src/metrics.ts
 
 import { notNullOrUndefined } from './util';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const packageJSON = require('../package.json');
 
 export interface MetricsOptions {
     onError: OnError;
@@ -127,7 +125,7 @@ export default class Metrics {
             [this.headerName]: this.clientKey,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'x-unleash-sdk': `unleash-js@${packageJSON.version}`,
+            'x-unleash-sdk': `unleash-js@$__VERSION__`,
             'x-unleash-connection-id': this.connectionId,
             'x-unleash-appname': this.appName,
         };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,7 +1,7 @@
 // Simplified version of: https://github.com/Unleash/unleash-client-node/blob/main/src/metrics.ts
 
 import { notNullOrUndefined } from './util';
-import {sdkVersion} from "./version";
+import { sdkVersion } from './version';
 
 export interface MetricsOptions {
     onError: OnError;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const sdkVersion = `unleash-js@__VERSION__`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,14 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
+"@rollup/plugin-replace@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-6.0.2.tgz#2f565d312d681e4570ff376c55c5c08eb6f1908d"
+  integrity sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
 "@rollup/plugin-terser@^0.4.4":
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz#15dffdb3f73f121aa4fbb37e7ca6be9aeea91962"
@@ -2977,9 +2985,9 @@ rollup-pluginutils@^2.8.1:
     estree-walker "^0.6.1"
 
 rollup@^3.29.4:
-  version "3.29.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
-  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
+  version "3.29.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.5.tgz#8a2e477a758b520fb78daf04bca4c522c1da8a54"
+  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Removes requiring version at runtime with require: https://github.com/Unleash/unleash-proxy-client-js/commit/3615f15dd4e297f0f82ea17eeec6f9791cf16f67#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R3

Instead we're using the rollup replace plugin to read the version at build time and replace `__VERSION__` placeholder with the actual version number.

As a result other packages depending on this one don't need to understand require calls and also we're not exposing the whole package.json file at runtime.

To verify my claim above you can build the package and check the build directory after this change vs before this change.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
