### PR TITLE
chore(1-3230): use homebrew version of uuid generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { TinyEmitter } from 'tiny-emitter';
-import { v4 as uuidv4 } from 'uuid';
 import Metrics from './metrics';
 import type IStorageProvider from './storage-provider';
 import InMemoryStorageProvider from './storage-provider-inmemory';
@@ -11,6 +10,7 @@ import {
     urlWithContextAsQuery,
 } from './util';
 import { sdkVersion } from './version';
+import { uuidv4 } from './uuidv4';
 
 const DEFINED_FIELDS = [
     'userId',

--- a/src/uuidv4.ts
+++ b/src/uuidv4.ts
@@ -1,0 +1,14 @@
+/**
+ * This function generates a UUID using Math.random().
+ * The distribution of unique values is not guaranteed to be as robust
+ * as with a crypto module but works across all platforms (Node, React Native, browser JS).
+ *
+ * We use it for connection id generation which is not critical for security.
+ */
+export const uuidv4 = (): string => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+};


### PR DESCRIPTION
The one from the uuid library relies on an underlying crypto library
which doesn't exist at least in certain GitHub runners and may also
cause issues for react native applications.

This impl sidesteps that issue.

The same uuid generation method that we're cutting out here is also being used in `src/events-handler.ts`. However, because we haven't received any complaints about that, I'll leave it in.