### PR TITLE
Update x-unleash-sdk in JS sdks to match `:` convention

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1382,7 +1382,7 @@ test('Should add `x-unleash` headers', async () => {
 
     const expectedHeaders = {
         // will be replaced at build time with the actual version
-        'x-unleash-sdk': 'unleash-js@__VERSION__',
+        'x-unleash-sdk': 'unleash-client-js:__VERSION__',
         'x-unleash-connection-id': expect.stringMatching(uuidFormat),
         'x-unleash-appname': appName,
     };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const sdkVersion = `unleash-js@__VERSION__`;
+export const sdkVersion = `unleash-client-js:__VERSION__`;


### PR DESCRIPTION
## About the changes
Changing `unleash-<lang>@<ver>` to `unleash-client-<lang>:<ver>`, because we have it this way in most SDKs on "register" requests.

Internal ticket: [issue/1-3283](https://linear.app/unleash/issue/1-3283/update-x-unleash-sdk-in-js-sdks-to-match-convention)