### PR TITLE
fix: unstable async bootstrap initialization

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
     IConfig,
     IMutableContext,
     IToggle,
+    IVariant,
     InMemoryStorageProvider,
     UnleashClient,
     lastUpdateKey,
@@ -315,6 +316,56 @@ test('Should bootstrap data when bootstrap is provided', async () => {
 
     expect(client.getAllToggles()).toStrictEqual(bootstrap);
     expect(localStorage.getItem(storeKey)).toBe(JSON.stringify(bootstrap));
+});
+
+it('should return correct variant if called asynchronously multiple times', async () => {
+    const bootstrap = [
+        {
+            name: 'foo',
+            enabled: true,
+            variant: {
+                name: 'A',
+                enabled: true,
+                payload: {
+                    type: 'string',
+                    value: 'FOO',
+                },
+            },
+            impressionData: false,
+        },
+    ];
+
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        refreshInterval: 0,
+        metricsInterval: 0,
+        disableRefresh: true,
+        bootstrapOverride: true,
+        bootstrap,
+        createAbortController: () => null,
+    };
+    const client = new UnleashClient(config);
+
+    const results: IVariant[] = [];
+    const expected: IVariant[] = [];
+
+    for (let i = 0; i < 10; i++) {
+        await true;
+        results.push(client.getVariant('foo'));
+        expected.push({
+            name: 'A',
+            enabled: true,
+            feature_enabled: true,
+            payload: {
+                type: 'string',
+                value: 'FOO',
+            },
+        });
+    }
+
+    expect(results).toEqual(expected);
 });
 
 test('Should set internal toggle state when bootstrap is set, before client is started', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -348,13 +348,10 @@ it('should return correct variant if called asynchronously multiple times', asyn
     };
     const client = new UnleashClient(config);
 
-    const results: IVariant[] = [];
-    const expected: IVariant[] = [];
-
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 12; i++) {
         await true;
-        results.push(client.getVariant('foo'));
-        expected.push({
+
+        expect(client.getVariant('foo')).toEqual({
             name: 'A',
             enabled: true,
             feature_enabled: true,
@@ -364,8 +361,6 @@ it('should return correct variant if called asynchronously multiple times', asyn
             },
         });
     }
-
-    expect(results).toEqual(expected);
 });
 
 test('Should set internal toggle state when bootstrap is set, before client is started', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,7 +7,6 @@ import {
     IConfig,
     IMutableContext,
     IToggle,
-    IVariant,
     InMemoryStorageProvider,
     UnleashClient,
     lastUpdateKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,8 +395,8 @@ export class UnleashClient extends TinyEmitter {
         const sessionId = await this.resolveSessionId();
         this.context = { sessionId, ...this.context };
 
-        this.lastRefreshTimestamp = await this.getLastRefreshTimestamp();
         const storedToggles = (await this.storage.get(storeKey)) || [];
+        this.lastRefreshTimestamp = await this.getLastRefreshTimestamp();
 
         if (
             this.bootstrap &&
@@ -412,9 +412,9 @@ export class UnleashClient extends TinyEmitter {
             this.setReady();
         } else {
             this.toggles = storedToggles;
-            this.sdkState = 'healthy';
         }
 
+        this.sdkState = 'healthy';
         this.emit(EVENTS.INIT);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,7 @@ export class UnleashClient extends TinyEmitter {
         this.context = { sessionId, ...this.context };
 
         this.lastRefreshTimestamp = await this.getLastRefreshTimestamp();
-        const storedToggles = await this.storage.get(storeKey) || []
+        const storedToggles = (await this.storage.get(storeKey)) || [];
 
         if (
             this.bootstrap &&
@@ -412,9 +412,9 @@ export class UnleashClient extends TinyEmitter {
             this.setReady();
         } else {
             this.toggles = storedToggles;
+            this.sdkState = 'healthy';
         }
 
-        this.sdkState = 'healthy';
         this.emit(EVENTS.INIT);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,12 +395,12 @@ export class UnleashClient extends TinyEmitter {
         const sessionId = await this.resolveSessionId();
         this.context = { sessionId, ...this.context };
 
-        this.toggles = (await this.storage.get(storeKey)) || [];
         this.lastRefreshTimestamp = await this.getLastRefreshTimestamp();
+        const storedToggles = await this.storage.get(storeKey) || []
 
         if (
             this.bootstrap &&
-            (this.bootstrapOverride || this.toggles.length === 0)
+            (this.bootstrapOverride || storedToggles.length === 0)
         ) {
             await this.storage.save(storeKey, this.bootstrap);
             this.toggles = this.bootstrap;
@@ -410,6 +410,8 @@ export class UnleashClient extends TinyEmitter {
             await this.storeLastRefreshTimestamp();
 
             this.setReady();
+        } else {
+            this.toggles = storedToggles;
         }
 
         this.sdkState = 'healthy';


### PR DESCRIPTION
## About the changes
Retrieve stored into a temporary variable, instead of overriding it for the duration of a next promise. Avoid race conditions.

Before this change calls to `isEnabled` or `getVariant` could be resolved between stored toggles (empty list) are resolved and bootstrapped toggles are restored. This was causing https://github.com/Unleash/unleash-client-nextjs/issues/106 