### PR TITLE
fix(metrics): use clearInterval instead of clearTimeout in stop()

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -107,7 +107,7 @@ export default class Metrics {
 
     public stop() {
         if (this.timer) {
-            clearTimeout(this.timer);
+            clearInterval(this.timer);
             delete this.timer;
         }
     }


### PR DESCRIPTION
## About the changes
When using unleash-proxy-client on the server side (e.g., for SSR or per-request flag fetching), we observed increasing memory usage and event loop handles even though .stop() was called immediately after .start().

After investigation, the issue was resolved by setting disableMetrics: true, suggesting that .stop () does not properly clean up background metrics collection.

Closes #245
