### PR TITLE
Handle already aborted controllers before re-aborting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -545,7 +545,8 @@ export class UnleashClient extends TinyEmitter {
 
     private async fetchToggles() {
         if (this.fetch) {
-            if (this.abortController) {
+            // Check if abortController is already aborted before calling abort
+            if (this.abortController && !this.abortController.signal.aborted) {
                 this.abortController.abort();
             }
             this.abortController = this.createAbortController?.();


### PR DESCRIPTION
Previously, the code attempted to abort controllers without checking their state, potentially causing issues. This change ensures that controllers are only aborted if they are not already in an aborted state, improving robustness and preventing unnecessary operations.

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
