### PR TITLE
fix: old vs new abort controller

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -553,11 +553,13 @@ export class UnleashClient extends TinyEmitter {
 
     private async fetchToggles() {
         if (this.fetch) {
-            // Check if abortController is already aborted before calling abort
-            if (this.abortController && !this.abortController.signal.aborted) {
-                this.abortController.abort();
-            }
+            const oldController = this.abortController;
             this.abortController = this.createAbortController?.();
+            // Check if abortController is already aborted before calling abort
+            if (oldController && !oldController.signal.aborted) {
+                oldController.abort();
+            }
+
             const signal = this.abortController
                 ? this.abortController.signal
                 : undefined;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

My hypothesis: in some environments, this.createAbortController might reuse an existing AbortController instance (e.g. a polyfill or a bad custom wrapper).

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
