### PR TITLE
fix: make setContextField and removeContextField be async

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1174,7 +1174,7 @@ test('Should setContextField with userId', async () => {
         appName: 'web',
     };
     const client = new UnleashClient(config);
-    client.setContextField('userId', userId);
+    await client.setContextField('userId', userId);
     const context = client.getContext();
     expect(context.userId).toBe(userId);
 });
@@ -1188,17 +1188,28 @@ test('Should removeContextField', async () => {
         appName: 'web',
     };
     const client = new UnleashClient(config);
-    client.setContextField('userId', userId);
+    await client.setContextField('userId', userId);
     client.setContextField('customField', customValue);
+    const context1 = client.getContext();
+    expect(context1).toEqual({
+        appName: 'web',
+        environment: 'default',
+        properties: {
+            customField: customValue,
+        },
+        sessionId: expect.any(String),
+        userId: userId,
+    });
 
-    client.removeContextField('userId');
-    client.removeContextField('customField');
-    const context = client.getContext();
+    await client.removeContextField('userId');
+    await client.removeContextField('customField');
+    const context2 = client.getContext();
 
-    expect(context).toEqual({
+    expect(context2).toEqual({
         appName: 'web',
         environment: 'default',
         properties: {},
+        sessionId: expect.any(String),
     });
 });
 
@@ -1210,7 +1221,7 @@ test('Should setContextField with sessionId', async () => {
         appName: 'web',
     };
     const client = new UnleashClient(config);
-    client.setContextField('sessionId', sessionId);
+    await client.setContextField('sessionId', sessionId);
     const context = client.getContext();
     expect(context.sessionId).toBe(sessionId);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,7 +373,7 @@ export class UnleashClient extends TinyEmitter {
         return { ...this.context };
     }
 
-    public setContextField(field: string, value: string) {
+    public async setContextField(field: string, value: string): Promise<void> {
         if (isDefinedContextField(field)) {
             this.context = { ...this.context, [field]: value };
         } else {
@@ -381,17 +381,17 @@ export class UnleashClient extends TinyEmitter {
             this.context = { ...this.context, properties };
         }
 
-        this.updateToggles();
+        await this.updateToggles();
     }
 
-    public removeContextField(field: string): void {
+    public async removeContextField(field: string): Promise<void> {
         if (isDefinedContextField(field)) {
             this.context = { ...this.context, [field]: undefined };
         } else if (typeof this.context.properties === 'object') {
             delete this.context.properties[field];
         }
 
-        this.updateToggles();
+        await this.updateToggles();
     }
 
     private setReady() {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
`setContextField` and `removeContextField` uses `updateToggles` inside like `updateContext` but both `setContextField` and `removeContextField` don't await `updateToggles`. Lead to a case that will get toggle that use old context value.

This fix is add async to both function like `updateContext` does. Now we can await both function


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->
