### PR TITLE
fix: add missing export EVENTS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -662,3 +662,5 @@ export class UnleashClient extends TinyEmitter {
 export { type IStorageProvider, LocalStorageProvider, InMemoryStorageProvider };
 
 export type { IConfig, IContext, IMutableContext, IVariant, IToggle };
+
+export { EVENTS } from './events';


### PR DESCRIPTION
Adds export for `EVENTS` in `index.ts`