### PR TITLE
fix: prevent double slashes in metrics URL

### DIFF
--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -1,6 +1,10 @@
 import { FetchMock } from 'jest-fetch-mock';
 import Metrics from './metrics';
-import { getTypeSafeRequest, parseRequestBodyWithType } from './test';
+import {
+    getTypeSafeRequest,
+    getTypeSafeRequestUrl,
+    parseRequestBodyWithType,
+} from './test';
 import { InMemoryMetricRegistry } from './impact-metrics/metric-types';
 
 jest.useFakeTimers();
@@ -335,6 +339,49 @@ describe('Custom headers for metrics', () => {
             'unleash-connection-id': '123',
         });
     });
+});
+
+test('should construct correct metrics URL', async () => {
+    const metrics = new Metrics({
+        onError: console.error,
+        appName: 'test',
+        metricsInterval: 0,
+        disableMetrics: false,
+        url: 'http://localhost:3000/api/frontend',
+        clientKey: '123',
+        fetch: fetchMock,
+        headerName: 'Authorization',
+        metricsIntervalInitial: 0,
+        connectionId: '123',
+    });
+
+    metrics.count('foo', true);
+    await metrics.sendMetrics();
+
+    const url = getTypeSafeRequestUrl(fetchMock);
+    expect(url).toBe('http://localhost:3000/api/frontend/client/metrics');
+});
+
+test('should not construct metrics URL with double slashes', async () => {
+    const metrics = new Metrics({
+        onError: console.error,
+        appName: 'test',
+        metricsInterval: 0,
+        disableMetrics: false,
+        url: 'http://localhost:3000/api/frontend/',
+        clientKey: '123',
+        fetch: fetchMock,
+        headerName: 'Authorization',
+        metricsIntervalInitial: 0,
+        connectionId: '123',
+    });
+
+    metrics.count('foo', true);
+    await metrics.sendMetrics();
+
+    const url = getTypeSafeRequestUrl(fetchMock);
+    expect(url).toBe('http://localhost:3000/api/frontend/client/metrics');
+    expect(url).not.toBe('http://localhost:3000/api/frontend//client/metrics');
 });
 
 describe('Flush metrics on page hidden', () => {

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -341,27 +341,6 @@ describe('Custom headers for metrics', () => {
     });
 });
 
-test('should construct correct metrics URL', async () => {
-    const metrics = new Metrics({
-        onError: console.error,
-        appName: 'test',
-        metricsInterval: 0,
-        disableMetrics: false,
-        url: 'http://localhost:3000/api/frontend',
-        clientKey: '123',
-        fetch: fetchMock,
-        headerName: 'Authorization',
-        metricsIntervalInitial: 0,
-        connectionId: '123',
-    });
-
-    metrics.count('foo', true);
-    await metrics.sendMetrics();
-
-    const url = getTypeSafeRequestUrl(fetchMock);
-    expect(url).toBe('http://localhost:3000/api/frontend/client/metrics');
-});
-
 test('should not construct metrics URL with double slashes', async () => {
     const metrics = new Metrics({
         onError: console.error,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -149,7 +149,7 @@ export default class Metrics {
     }: { fireAndForget?: boolean } = {}): Promise<void> {
         /* istanbul ignore next if */
 
-        const url = `${this.url}/client/metrics`;
+        const url = `${this.url.toString().replace(/\/$/, '')}/client/metrics`;
         const payload = this.getPayload();
 
         if (


### PR DESCRIPTION
Strips any trailing slash from the base URL before appending `/client/metrics`.

When the configured base URL has a trailing slash (e.g. `http://localhost:3000/api/frontend/`), the SDK constructed URLs like `http://localhost:3000/api/frontend//client/metrics` (spotted while making [this test](https://github.com/Unleash/unleash/blob/main/frontend/src/hooks/useImpactMetrics.test.tsx#L22) in Unleash). 
We never noticed because Unleash runs on Express which normalizes paths by default, but still worth fixing I think.
