### PR TITLE
fix: remove `uuid` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   },
   "homepage": "https://github.com/unleash/unleash-js-sdk#readme",
   "dependencies": {
-    "tiny-emitter": "^2.1.0",
-    "uuid": "^9.0.1"
+    "tiny-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.1",
@@ -50,7 +49,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/jest": "^29.5.5",
-    "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
     "eslint": "^8.51.0",

--- a/src/events-handler.ts
+++ b/src/events-handler.ts
@@ -1,5 +1,5 @@
 import { IContext } from '.';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from './uuidv4';
 
 class EventsHandler {
     private generateEventId() {

--- a/src/uuidv4.ts
+++ b/src/uuidv4.ts
@@ -1,9 +1,12 @@
 /**
- * This function generates a UUID using crypto.randomUUID(), falling back to Math.random().
- * The distribution of unique values is not guaranteed to be as robust
- * as with a crypto module but works across all platforms (Node, React Native, browser JS).
+ * Generates a UUIDv4-style identifier using crypto.randomUUID(), falling back to Math.random().
+ * When crypto.randomUUID() is available, it should provide a standard, cryptographically strong UUID.
+ * The fallback preserves the UUIDv4 shape for compatibility across platforms (Node, React Native,
+ * browser JS), but its uniqueness and unpredictability are not as robust as a crypto-backed source.
  *
- * We use it for connection id generation which is not critical for security.
+ * We use this helper for non-security-critical identifiers such as connection IDs and event IDs.
+ * Callers should treat fallback-generated values as best-effort unique identifiers, not as
+ * security-sensitive or globally uniqueness-guaranteed tokens.
  */
 
 export const uuidv4 = (): string => {

--- a/src/uuidv4.ts
+++ b/src/uuidv4.ts
@@ -1,11 +1,16 @@
 /**
- * This function generates a UUID using Math.random().
+ * This function generates a UUID using crypto.randomUUID(), falling back to Math.random().
  * The distribution of unique values is not guaranteed to be as robust
  * as with a crypto module but works across all platforms (Node, React Native, browser JS).
  *
  * We use it for connection id generation which is not critical for security.
  */
+
 export const uuidv4 = (): string => {
+    if (typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         const r = (Math.random() * 16) | 0;
         const v = c === 'x' ? r : (r & 0x3) | 0x8;

--- a/src/uuidv4.ts
+++ b/src/uuidv4.ts
@@ -8,7 +8,6 @@
  * Callers should treat fallback-generated values as best-effort unique identifiers, not as
  * security-sensitive or globally uniqueness-guaranteed tokens.
  */
-
 export const uuidv4 = (): string => {
     if (typeof crypto.randomUUID === 'function') {
         return crypto.randomUUID();

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,11 +813,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/uuid@^9.0.5":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
-
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -3421,11 +3416,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #283
Closes #282



<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

`uuidv4.ts` is now used also for event generation.

It tries to use the global `crypto` module, falling back to the old implementation. Note that npm package `uuid` will do this for v4, so when you _only_ use v4 upgrading to latest `uuid@v14` it is a dead dependency


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Nah, should be good to go. Unless the uuid in the events _need_ to be valid uuid, and we need to support envs without `crypto`. I haven't done any react native for 3 years - dunno how their support is? It works from expo web, but I dunno if that just allows web APIs: https://snack.expo.dev/@simenb/moody-violet-fudge