### PR TITLE
chore: move Node version for tests to more modern 20-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 16 and 18 are no longer compatible with up to date dev dependencies. Current versions of those dev dependencies have open vulnerabilities, which need to be closed. Node isn't actually a targeted runtime for this SDK, it's just being used to run tests, we can just drop 16+18, it's fine

Skipping the requirements on this - since Node 16 and 18 are required but removed, they won't pass, that's expected